### PR TITLE
Changed to Crown Copyright and renamed to LICENCE

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,6 +1,6 @@
-MIT License
+MIT Licence
 
-Copyright (c) 2025 Department for Education - Digital
+Copyright (c) 2025 Crown Copyright (Department for Education)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Changed to Crown Copyright and renamed to LICENCE according to DfE guidance