### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,2 @@
 # This sets the default owner for all code.
 * @DFE-Digital/csc-social-work-swip-dev
-* @DFE-Digital/csc-social-work-swip-devops


### PR DESCRIPTION
Removed the devops team from default code owner until we have devops folders we can set the team as codeowners for