### PR TITLE
SWIP-247 - Use official Moodle base image and optimise image layers

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -30,16 +30,6 @@ services:
       timeout: 10s
       retries: 5
 
-  pgadmin:
-    image: dpage/pgadmin4
-    ports:
-      - "8081:80"
-    environment:
-      - PGADMIN_DEFAULT_EMAIL=admin@admin.com
-      - PGADMIN_DEFAULT_PASSWORD=admin
-    depends_on:
-      - postgres
-
 volumes:
   pgdata:
   moodledata:

--- a/justfile
+++ b/justfile
@@ -1,6 +1,9 @@
 start:
   docker compose up --build -d
 
+build:
+  docker compose build --no-cache --parallel
+
 stop:
   docker compose down
 

--- a/moodle-docker/Dockerfile
+++ b/moodle-docker/Dockerfile
@@ -1,56 +1,23 @@
-# Use the official PHP 8.3 image as a base
-FROM php:8.3-apache
+# Use the [official Moodle PHP-apache image](https://github.com/moodlehq/moodle-php-apache) as a base
+FROM moodlehq/moodle-php-apache:8.3-bookworm
 
-# Install necessary extensions, Apache mod_rewrite, Composer, PostgreSQL extension, and OPcache
-RUN apt-get update && \
-  apt-get install -y --no-install-recommends unzip git curl libzip-dev libjpeg-dev libpng-dev \
-  libfreetype6-dev libicu-dev libxml2-dev libpq-dev && \
-  docker-php-ext-configure gd --with-freetype --with-jpeg && \
-  docker-php-ext-install mysqli zip gd intl soap exif pgsql pdo_pgsql opcache && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* && \
-  git clone git://git.moodle.org/moodle.git && cd moodle && \
-  git branch --track MOODLE_405_STABLE origin/MOODLE_405_STABLE && \
-  git checkout MOODLE_405_STABLE && \
-  cp -rf ./* /var/www/html/
+USER www-data
 
-# Set PHP settings for Moodle: max_input_vars and OPcache
-RUN echo "max_input_vars=5000" >> /usr/local/etc/php/conf.d/docker-php-moodle.ini && \
-  echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/docker-php-opcache.ini && \
-  echo "opcache.enable_cli=1" >> /usr/local/etc/php/conf.d/docker-php-opcache.ini && \
-  echo "opcache.memory_consumption=128" >> /usr/local/etc/php/conf.d/docker-php-opcache.ini && \
-  echo "opcache.interned_strings_buffer=8" >> /usr/local/etc/php/conf.d/docker-php-opcache.ini && \
-  echo "opcache.max_accelerated_files=10000" >> /usr/local/etc/php/conf.d/docker-php-opcache.ini && \
-  echo "opcache.revalidate_freq=60" >> /usr/local/etc/php/conf.d/docker-php-opcache.ini && \
-  echo "opcache.validate_timestamps=1" >> /usr/local/etc/php/conf.d/docker-php-opcache.ini
-
-# Create moodledata directory
-RUN mkdir -p /var/www/moodledata
-
-# Set working directory
-WORKDIR /var/www/html
-
-## Theme install
-
-# Set the GitHub release URL (modify this based on the actual repository)
-ARG GITHUB_RELEASE_URL="https://github.com/DFE-Digital/govuk-moodle-theme/releases/download/2024200800/govuk-moodle-theme.zip"
+# Clone the Moodle source code
+RUN git clone -b MOODLE_405_STABLE --single-branch --depth=1 git://git.moodle.org/moodle.git && \
+  mv -f ./moodle/* /var/www/html/ && rm -rf ./moodle
 
 # Download and extract the theme
+ARG GITHUB_RELEASE_URL="https://github.com/DFE-Digital/govuk-moodle-theme/releases/download/2024200800/govuk-moodle-theme.zip"
 RUN curl -L -o /tmp/govuk-moodle-theme.zip "$GITHUB_RELEASE_URL" \
-    && unzip /tmp/govuk-moodle-theme.zip -d /tmp/theme \
-    && mv /tmp/theme/govuk/ /var/www/html/theme/ \
-    && rm /tmp/govuk-moodle-theme.zip
+  && unzip /tmp/govuk-moodle-theme.zip -d /tmp/theme \
+  && mv /tmp/theme/govuk/ /var/www/html/theme/ \
+  && rm /tmp/govuk-moodle-theme.zip
 
-# Set the correct permissions
-RUN chown -R www-data:www-data /var/www/ && chmod -R 755 /var/www
+WORKDIR /var/www/html
 
-# Enable Apache rewrite module (if needed for Moodle)
-RUN a2enmod rewrite
+USER root
 
-# Restart Apache
 CMD ["apache2-foreground"]
 
-## End theme install 
-
-# Expose port 80
 EXPOSE 80


### PR DESCRIPTION
- Removes unnecessary PGAdmin container from compose file
- Adds `just build` command to easily force a rebuild of the docker image
- Uses the official [Moodle PHP Apache](https://github.com/moodlehq/moodle-php-apache) docker image as a base
- Utilises `USER` statements to simplify permissions in image and remove need for `chown`/`chmod` which took a long time to do recursively
- Optimises git clone of Moodle source to only checkout a single branch with a depth of `1` to strip unnecessary git history data
- Deletes unnecessary files from cloned dir after copying the Moodle source to the www root

Reduced the build time (with cached base images) from 400+ seconds to ~20s (on my local machine)
Reduced the image size from 3.03GB to 1.46GB