### PR TITLE
SWIP-234 - Map local config.php file as docker volume to pre-select govuk theme

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -8,6 +8,7 @@ services:
       - 8080:80
     volumes:
       - moodledata:/var/www/moodledata
+      - ${PWD}/moodle-docker/config.php:/var/www/html/config.php
     depends_on:
       postgres:
         condition: service_healthy

--- a/moodle-docker/config.php
+++ b/moodle-docker/config.php
@@ -1,0 +1,32 @@
+<?php  // Moodle configuration file
+
+unset($CFG);
+global $CFG;
+$CFG = new stdClass();
+
+$CFG->dbtype    = 'pgsql';
+$CFG->dblibrary = 'native';
+$CFG->dbhost    = 'postgres';
+$CFG->dbname    = 'moodle';
+$CFG->dbuser    = 'moodle_user';
+$CFG->dbpass    = 'moodle_password';
+$CFG->prefix    = 'mdl_';
+$CFG->dboptions = array (
+  'dbpersist' => 0,
+  'dbport' => 5432,
+  'dbsocket' => '',
+);
+
+$CFG->wwwroot   = 'http://localhost:8080';
+$CFG->dataroot  = '/var/www/moodledata';
+$CFG->admin     = 'admin';
+
+$CFG->directorypermissions = 02777;
+
+# Uncomment to set the theme
+#$CFG->theme = 'govuk';
+
+require_once(__DIR__ . '/lib/setup.php');
+
+// There is no php closing tag in this file,
+// it is intentional because it prevents trailing whitespace problems!

--- a/scripts/install-moodle.sh
+++ b/scripts/install-moodle.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker exec -it --user www-data moodle-web php /var/www/html/admin/cli/install.php --non-interactive --agree-license --wwwroot=http://localhost:8080 --dbtype=pgsql --dbhost=postgres --dbport=5432 --dbname=moodle --dbuser=moodle_user --dbpass=moodle_password --fullname="Moodle Demo" --shortname=Demo --adminpass=password
+docker exec -it --user www-data moodle-web php /var/www/html/admin/cli/install_database.php --agree-license --fullname="Social Work Induction Programme" --shortname=SWIP --adminpass=password --adminemail=admin@email.com


### PR DESCRIPTION
- Added `config.php` file and mapped in `compose.yml` to Moodle's config.
- `$CFG->theme` set to `govuk` in `config.php`. Commented out by default until theme is more functional.
- Updated `install-moodle.sh` to use `install_database.php` as `install.php` won't work if `config.php` already exists. `install_database.php` will setup the DB with the necessary schema based on the config.