### PR TITLE
SWIP-197 - Set default theme to govuk

### DIFF
--- a/moodle-docker/config.php
+++ b/moodle-docker/config.php
@@ -40,8 +40,7 @@ $CFG->admin = getenv('MOODLE_ADMIN_USER');
 
 $CFG->directorypermissions = 02777;
 
-# Uncomment to set the theme
-#$CFG->theme = 'govuk';
+$CFG->theme = 'govuk';
 
 require_once(__DIR__ . '/lib/setup.php');
 


### PR DESCRIPTION
Now that the navbar styling has been done and it pulls navigation data from Moodle, we can set the default theme to the GovUK theme without breaking the functionality of the site.

To change the theme, you will need to update this config setting locally.