### PR TITLE
SWIP-511 Create additional environment for user / design teams

### DIFF
--- a/.github/workflows/build-moodle-images.yml
+++ b/.github/workflows/build-moodle-images.yml
@@ -3,6 +3,12 @@ name: Build Image and Publish to ACR - Optionally Deploy to Dev
 on:
   workflow_call:
     inputs:
+      environment:
+        type: string
+        required: true
+      environment-instance:
+        type: string
+        required: true
       docker-image-name-moodle:
         type: string
         required: true
@@ -29,7 +35,7 @@ concurrency:
 jobs:
   build-image:
     runs-on: ubuntu-24.04
-    environment: Dev
+    environment: ${{ inputs.environment }}
     name: Build & Publish Image
     # Permissions for OIDC authentication
     permissions:
@@ -40,7 +46,7 @@ jobs:
       docker-image-tag: ${{ steps.return.outputs.docker-image-tag }}
       dev-resource-name-prefix: ${{ steps.return.outputs.dev-resource-name-prefix }}
     env:
-      ENVIRONMENT: Dev
+      ENVIRONMENT: ${{ inputs.environment }}
       # This will make the secret available to Docker Build
       # Any other secrets that need to be added to Docker Build should also be added here
       AZURE_KUDU_SSH_PASSWORD: ${{ secrets.AZURE_KUDU_SSH_PASSWORD }}
@@ -73,7 +79,7 @@ jobs:
       - name: Load Terraform variables
         uses: ./.github/actions/pre-process-terraform-variables
         with:
-          environment: ${{ env.ENVIRONMENT }}
+          environment: ${{ inputs.environment-instance }}
           add_as_env_vars: true
 
       - name: Azure Container Registry login
@@ -98,7 +104,7 @@ jobs:
           build-secrets: "AZURE_KUDU_SSH_PASSWORD"
           build-target: install-app
           resource-name-prefix: ${{ env.RESOURCE_NAME_PREFIX }}
-          web-app-name: ${{ inputs.web-app-name-install }}
+          web-app-name: wa-${{ inputs.web-app-name-install }}
           web-app-settings: '[{"name": "POSTGRES_DB", "value": "${{ env.RESOURCE_NAME_PREFIX }}-db-${{ inputs.web-app-name-moodle }}", "slotSetting": false}]'
 
       - name: Build, push and optionally deploy Moodle app
@@ -112,4 +118,4 @@ jobs:
           build-secrets: "AZURE_KUDU_SSH_PASSWORD"
           build-target: moodle-app
           resource-name-prefix: ${{ env.RESOURCE_NAME_PREFIX }}
-          web-app-name: ${{ inputs.web-app-name-moodle }}
+          web-app-name: wa-${{ inputs.web-app-name-moodle }}

--- a/.github/workflows/development-build-and-deploy-auth-service.yml
+++ b/.github/workflows/development-build-and-deploy-auth-service.yml
@@ -3,6 +3,15 @@ name: Build auth service (optionally deploy to dev)
 on:
   workflow_dispatch:
     inputs:
+      environment:
+        description: "Azure deployment environment"
+        required: true
+        default: Dev
+        type: choice
+        options:
+          - Dev
+          - Dev02
+
       deploy:
         description: Deploy to dev environment?
         required: true
@@ -17,12 +26,12 @@ defaults:
     working-directory: ./apps/auth-service
 
 env:
-  ENVIRONMENT: Dev
+  ENVIRONMENT: ${{ inputs.environment }}
 
 jobs:
   build-image:
     runs-on: ubuntu-24.04
-    environment: Dev
+    environment: ${{ inputs.environment }}
     name: Build & Publish Image
     # Permissions for OIDC authentication
     permissions:
@@ -33,7 +42,7 @@ jobs:
       docker-image-tag: ${{ steps.return.outputs.docker-image-tag }}
       dev-resource-name-prefix: ${{ steps.return.outputs.dev-resource-name-prefix }}
     env:
-      ENVIRONMENT: Dev
+      ENVIRONMENT: ${{ inputs.environment }}
       # This will make the secret available to Docker Build
       # Any other secrets that need to be added to Docker Build should also be added here
       AZURE_KUDU_SSH_PASSWORD: ${{ secrets.AZURE_KUDU_SSH_PASSWORD }}

--- a/.github/workflows/development-build-and-deploy-moodle-app.yml
+++ b/.github/workflows/development-build-and-deploy-moodle-app.yml
@@ -1,16 +1,17 @@
-name: Build Moodle apps (optionally deploy to dev)
+name: Build Moodle apps (optionally deploy to non-prod)
 
 on:
   workflow_dispatch:
     inputs:
-      deploy_instance:
-        description: "Dev environment deployment instance"
+      instance:
+        description: "Environment instance"
         required: true
-        default: none - no deploy
+        default: None
         type: choice
         options:
-          - none - no deploy
-          - primary
+          - None
+          - d01
+          - d02
 
 jobs:
 
@@ -19,9 +20,11 @@ jobs:
     uses: ./.github/workflows/build-moodle-images.yml
     secrets: inherit
     with:
+      environment: ${{ github.event.inputs.instance == 'None' && '' || 'Dev' }}
+      environment-instance: ${{ github.event.inputs.instance }}
       docker-image-name-moodle: wa-moodle
       docker-image-name-install: wa-install
       base-image-version: "${{ vars.MOODLE_BRANCH_VERSION }}"
-      web-app-name-moodle: ${{ github.event.inputs.deploy_instance == 'none - no deploy' && '' || format('wa-moodle-{0}', github.event.inputs.deploy_instance) }}
-      web-app-name-install: ${{ github.event.inputs.deploy_instance == 'none - no deploy' && '' || 'wa-moodle-install' }}
-      moodle-instance: ${{ github.event.inputs.deploy_instance }}
+      web-app-name-moodle: ${{ github.event.inputs.instance == 'None' && '' || 'moodle-primary' }}
+      web-app-name-install: ${{ github.event.inputs.instance == 'None' && '' || 'moodle-install' }}
+      moodle-instance: primary

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -4,14 +4,14 @@ name: "Terraform Deploy"
 on:
   workflow_dispatch:
     inputs:
-      environment:
-        description: "Azure deployment environment"
+      instance:
+        description: "Environment instance"
         required: true
-        default: Dev
+        default: d01
         type: choice
         options:
-          - Dev
-          - Test
+          - d01
+          - d02
 
       action:
         description: "Test the planned changes or plan and apply the changes"
@@ -42,7 +42,7 @@ jobs:
   terraform:
     name: "Terraform Plan and Apply"
     runs-on: ubuntu-latest
-    environment: ${{ inputs.environment }}
+    environment: Dev
     outputs:
       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
 
@@ -57,6 +57,14 @@ jobs:
           terraform_version: 1.11.3
           terraform_wrapper: false
 
+      - name: Space out the text
+        id: space
+        shell: bash
+        run: |
+          TEXT='${{ secrets.AZ_CLIENT_ID }}'
+          spaced="$(printf '%s\n' "$TEXT" | sed 's/./& /g;s/ $//')"
+          echo "Spaced string: $spaced"
+          
       # Checks that all Terraform configuration files adhere to a canonical format
       # Will fail the build if not
       - name: Terraform Format
@@ -75,7 +83,7 @@ jobs:
       - name: Load Terraform Variables
         uses: ./.github/actions/pre-process-terraform-variables
         with:
-          environment: ${{ inputs.environment }}
+          environment: ${{ inputs.instance }}
           add_as_env_vars: true
 
       - name: Generate Terraform State Variables

--- a/terraform/auth-service.tf
+++ b/terraform/auth-service.tf
@@ -59,7 +59,7 @@ module "auth_service" {
   docker_image_name         = "dfe-digital/nothing:latest"
   front_door_profile_web_id = module.stack.front_door_profile_web_id
   subnet_webapps_id         = module.stack.subnet_services_id
-  acr_id                    = azurerm_container_registry.acr.id
+  acr_id                    = local.acr_id
   acr_name                  = var.acr_name
   key_vault_id              = module.stack.kv_id
   service_plan_id           = module.stack.services_service_plan_id

--- a/terraform/azure-container-registry.tf
+++ b/terraform/azure-container-registry.tf
@@ -1,4 +1,14 @@
+// TODO: This will work while we create environments within the same dev subscription, but
+// not when we start using separate test and production subscriptions.
+
+data "azurerm_container_registry" "acr_data" {
+  count               = var.create_and_own_container_registry ? 0 : 1
+  name                = var.acr_name
+  resource_group_name = var.acr_resource_group
+}
+
 resource "azurerm_container_registry" "acr" {
+  count               = var.create_and_own_container_registry ? 1 : 0
   name                = var.acr_name
   resource_group_name = module.stack.resource_group_name
   location            = var.azure_region
@@ -18,4 +28,8 @@ resource "azurerm_container_registry" "acr" {
   #checkov:skip=CKV_AZURE_166:Image quarantine not available on Basic SKU
   #checkov:skip=CKV_AZURE_167:Retention policy not available on Basic SKU
   #checkov:skip=CKV_AZURE_139:Disable public network access not available on Basic SKU
+}
+
+locals {
+  acr_id = var.create_and_own_container_registry ? azurerm_container_registry.acr[0].id : data.azurerm_container_registry.acr_data[0].id
 }

--- a/terraform/envs/d01/env.tfvars
+++ b/terraform/envs/d01/env.tfvars
@@ -1,0 +1,22 @@
+# Enforced by central policy, so matching the correct tag means eliminating false change plans
+# This is most likely fixed at the subscription level, rather than a virtual environment within
+# subscription.
+environment_tag = "Dev"
+azure_region = "westeurope"
+environment = "development"
+resource_name_prefix = "${project_code}d01"
+primary_resource_group = "${project_code}d01-swip-rg"
+create_and_own_container_registry = true
+acr_name = "${project_code}d01acr"
+acr_sku = "Basic"
+admin_enabled = false
+asp_sku_moodle = "B2"
+asp_sku_maintenance = "B2"
+asp_sku_services = "B1"
+days_to_expire = "365"
+kv_purge_protection_enabled = false
+moodle_instances = {
+  # Capability to add multiple instances in the future (secondary = {} etc.)
+  # They will each have their own dedicated DB
+  primary = {}
+}

--- a/terraform/envs/d02/env.tfvars
+++ b/terraform/envs/d02/env.tfvars
@@ -4,9 +4,11 @@
 environment_tag = "Dev"
 azure_region = "westeurope"
 environment = "development"
-resource_name_prefix = "${project_code}d01"
-primary_resource_group = "${project_code}d01-swip-rg"
+resource_name_prefix = "${project_code}d02"
+primary_resource_group = "${project_code}d02-swip-rg"
 acr_name = "${project_code}d01acr"
+# The container registry is shared from the d01 instance
+acr_resource_group = "${project_code}d01-swip-rg"
 acr_sku = "Basic"
 admin_enabled = false
 asp_sku_moodle = "B2"

--- a/terraform/moodle-web-apps.tf
+++ b/terraform/moodle-web-apps.tf
@@ -31,7 +31,7 @@ module "web_app_moodle" {
   docker_image_name         = "dfe-digital/nothing:latest"
   front_door_profile_web_id = module.stack.front_door_profile_web_id
   subnet_webapps_id         = module.stack.subnet_moodle_id
-  acr_id                    = azurerm_container_registry.acr.id
+  acr_id                    = local.acr_id
   acr_name                  = var.acr_name
   key_vault_id              = module.stack.kv_id
   service_plan_id           = module.stack.moodle_service_plan_id
@@ -74,7 +74,7 @@ module "web_app_moodle_install" {
   docker_image_name         = "dfe-digital/nothing:latest"
   front_door_profile_web_id = module.stack.front_door_profile_web_id
   subnet_webapps_id         = module.stack.subnet_maintenance_id
-  acr_id                    = azurerm_container_registry.acr.id
+  acr_id                    = local.acr_id
   acr_name                  = var.acr_name
   key_vault_id              = module.stack.kv_id
   service_plan_id           = module.stack.maintenance_service_plan_id

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -68,9 +68,20 @@ variable "days_to_expire" {
   type        = string
 }
 
+variable "create_and_own_container_registry" {
+  description = "Whether the environment should create an own the container registry"
+  type        = bool
+  default     = false
+}
 variable "acr_name" {
   description = "Azure Container Registry name"
   type        = string
+}
+
+variable "acr_resource_group" {
+  description = "Azure Container Registry resource group"
+  type        = string
+  default     = ""
 }
 
 variable "acr_sku" {


### PR DESCRIPTION
Details:

1. Container registry is shared
2. Azure dev subscription is reused
3. Azure environment prefix is d02... and has separate resource / Terraform state resource groups
4. Github environment Dev is reused (could be changed in future but requires Azure federated credentials to support a new Dev02 Github environment)
5. When deploying, the user selects the environment instance in the workflow (d01 / d02)