### PR TITLE
SWIP-311 OneLogin integration for auth service

### DIFF
--- a/.github/actions/check-endpoint-content/action.yml
+++ b/.github/actions/check-endpoint-content/action.yml
@@ -45,11 +45,11 @@ runs:
             if [ -n "$body" ]; then
               if [ "$body" == "$EXPECTED_RESPONSE" ]; then
                 RESPONSE="$body"
-                echo "✅ Got correct version response '$EXPECTED_RESPONSE' after ${elapsed}s:"
+                echo "✅ Got correct endpoint response '$EXPECTED_RESPONSE' after ${elapsed}s:"
                 echo "$RESPONSE"
                 break
               else
-                echo "⏳ Got incorrect version response '$body', expected '$EXPECTED_RESPONSE' after ${elapsed}s:"
+                echo "⏳ Got incorrect endpoint response '$body', expected '$EXPECTED_RESPONSE' after ${elapsed}s:"
               fi
             fi
           else

--- a/.github/workflows/deploy-app-service.yml
+++ b/.github/workflows/deploy-app-service.yml
@@ -86,6 +86,13 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v3
 
+      # Need to retrieve ACR_NAME in particular for next steps
+      - name: Load Terraform variables
+        uses: ./.github/actions/pre-process-terraform-variables
+        with:
+          environment: ${{ inputs.environment-instance }}
+          add-as-env-vars: true
+
       # This is mainly provided to fetch app settings that will drive the database update
       # process. E.g. MOODLE_DB_HOST;POSTGRES_DB;POSTGRES_USER;POSTGRES_PASSWORD
       # Also provides the app service domain name to drive the post deploy version check
@@ -94,6 +101,8 @@ jobs:
         shell: bash
         env:
           APP_SETTINGS: ${{ inputs.fetch-web-app-settings }}
+          WEB_APP_NAME: ${{ inputs.web-app-name }}
+          RESOURCE_GROUP: ${{ inputs.app-service-resource-group }}
         run: |
           set -euo pipefail
 
@@ -110,8 +119,8 @@ jobs:
 
           # Outputs "NAME<TAB>VALUE" per line
           az webapp config appsettings list \
-            --resource-group "${{ inputs.app-service-resource-group }}" \
-            --name         "${{ inputs.web-app-name }}" \
+            --resource-group "$RESOURCE_GROUP" \
+            --name         "$WEB_APP_NAME" \
             --query        "[?${FILTER}].[name,value]" \
             -o tsv \
           | while IFS=$'\t' read -r KEY VAL; do
@@ -136,6 +145,16 @@ jobs:
                 echo "REMOTE_TUNNEL_HOST=$VAL" >> "$GITHUB_ENV"
               fi
             done
+            # Retrieve front door host name for web app
+            FRONT_DOOR_HOST_NAME=$(az afd endpoint list \
+              --resource-group $RESOURCE_GROUP \
+              --profile-name $RESOURCE_NAME_PREFIX-fd-profile-web \
+              --query "[?name=='$RESOURCE_NAME_PREFIX-fd-endpoint-web-${WEB_APP_NAME#*-}'].hostName | [0]" \
+              --output tsv)
+            if [[ ! -z "$FRONT_DOOR_HOST_NAME" ]]; then
+              echo "Retrieved front door host name: $FRONT_DOOR_HOST_NAME for web app: $WEB_APP_NAME"
+              echo "FULL_EXTERNAL_WEB_DOMAIN_NAME=$FRONT_DOOR_HOST_NAME" >> "$GITHUB_ENV"
+            fi            
 
       - name: Establish remote tunnel (optional)
         if: inputs.tunnel-app-service != '' && inputs.app-service-resource-group != '' && inputs.tunnel-remote-server-name != '' && inputs.tunnel-remote-server-port != ''
@@ -145,13 +164,6 @@ jobs:
           resource-group: ${{ inputs.app-service-resource-group }}
           host-name: ${{ env.REMOTE_TUNNEL_HOST }}
           port: ${{ inputs.tunnel-remote-server-port }}
-
-      # Need to retrieve ACR_NAME in particular for next steps
-      - name: Load Terraform variables
-        uses: ./.github/actions/pre-process-terraform-variables
-        with:
-          environment: ${{ inputs.environment-instance }}
-          add-as-env-vars: true
 
       - name: Azure Container Registry login
         if: inputs.requires-container-registry-login

--- a/.github/workflows/deploy-auth-service.yml
+++ b/.github/workflows/deploy-auth-service.yml
@@ -12,6 +12,10 @@ on:
           - None
           - d01
           - d02
+      version-tag:
+        description: Version tag to deploy, e.g. 20250506.118df8a.dev
+        type: string
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
@@ -29,13 +33,13 @@ jobs:
       working-dir: ./apps/auth-service
       # These are app settings which are required to run the db update
       fetch-web-app-settings: "DB_SERVER_NAME;DB_DATABASE_NAME;DB_USER_NAME;DB_PASSWORD"
-      app-service-resource-group: s205d01-swip-rg
-      tunnel-app-service: s205d01-wa-proxy-service
+      app-service-resource-group: s205${{ (github.event_name == 'push' || github.event.inputs.instance == 'None') && 'd01' || github.event.inputs.instance }}-swip-rg
+      tunnel-app-service: s205${{ (github.event_name == 'push' || github.event.inputs.instance == 'None') && 'd01' || github.event.inputs.instance }}-wa-proxy-service
       # Get database server name from the app setting
       tunnel-remote-server-name: "DB_SERVER_NAME"
       tunnel-remote-server-port: 5432
       # DB updates will be performed through the auth service container
       requires-container-registry-login: true
-      web-app-name: s205d01-wa-auth-service
-      image-tag: s205d01acr.azurecr.io/dfe-digital-swip-digital-service/auth-service:20250506.118df8a.dev
+      web-app-name: s205${{ (github.event_name == 'push' || github.event.inputs.instance == 'None') && 'd01' || github.event.inputs.instance }}-wa-auth-service
+      image-tag: s205d01acr.azurecr.io/dfe-digital-swip-digital-service/auth-service:${{ github.event.inputs.version-tag }}
       version-endpoint-path: /api/accounts/version

--- a/.github/workflows/deploy-moodle-app.yml
+++ b/.github/workflows/deploy-moodle-app.yml
@@ -12,6 +12,10 @@ on:
           - None
           - d01
           - d02
+      version-tag:
+        description: Version tag to deploy, e.g. 405-20250507.57da7f9.dev
+        type: string
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
@@ -31,7 +35,20 @@ jobs:
       fetch-web-app-settings: "MOODLE_DOCKER_WEB_HOST;MOODLE_ADMIN_PASSWORD;POSTGRES_PASSWORD"
       # The app service is used to deploy db migrations after the publish
       execute-migrations-after-deploy: 'true'
-      app-service-resource-group: s205d01-swip-rg
-      web-app-name: s205d01-wa-moodle-primary
-      image-tag: s205d01acr.azurecr.io/dfe-digital-swip-digital-service/wa-moodle:405-20250501.741a6d1.dev
+      app-service-resource-group: s205${{ (github.event_name == 'push' || github.event.inputs.instance == 'None') && 'd01' || github.event.inputs.instance }}-swip-rg
+      web-app-name: s205${{ (github.event_name == 'push' || github.event.inputs.instance == 'None') && 'd01' || github.event.inputs.instance }}-wa-moodle-primary
+      image-tag: s205d01acr.azurecr.io/dfe-digital-swip-digital-service/wa-moodle:${{ github.event.inputs.version-tag }}
+      version-endpoint-path: /version.txt
+
+  deploy-moodle-cron-app:
+    if: ${{ github.event.inputs.instance != 'None' }}
+    name: Deploy Moodle Cron App
+    uses: ./.github/workflows/deploy-app-service.yml
+    secrets: inherit
+    with:
+      environment: Dev
+      environment-instance: ${{ (github.event_name == 'push' || github.event.inputs.instance == 'None') && 'd01' || github.event.inputs.instance }}
+      app-service-resource-group: s205${{ (github.event_name == 'push' || github.event.inputs.instance == 'None') && 'd01' || github.event.inputs.instance }}-swip-rg
+      web-app-name: s205${{ (github.event_name == 'push' || github.event.inputs.instance == 'None') && 'd01' || github.event.inputs.instance }}-wa-moodle-cron
+      image-tag: s205d01acr.azurecr.io/dfe-digital-swip-digital-service/wa-moodle:${{ github.event.inputs.version-tag }}
       version-endpoint-path: /version.txt

--- a/.github/workflows/deploy-proxy-service.yml
+++ b/.github/workflows/deploy-proxy-service.yml
@@ -12,6 +12,10 @@ on:
           - None
           - d01
           - d02
+      version-tag:
+        description: Version tag to deploy, e.g. 20250506.118df8a.dev
+        type: string
+        required: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
@@ -26,7 +30,7 @@ jobs:
     with:
       environment: Dev
       environment-instance: ${{ (github.event_name == 'push' || github.event.inputs.instance == 'None') && 'd01' || github.event.inputs.instance }}
-      app-service-resource-group: s205d01-swip-rg
-      web-app-name: s205d01-wa-proxy-service
-      image-tag: s205d01acr.azurecr.io/dfe-digital-swip-digital-service/proxy-service:405-20250429.a6f148f.dev
+      app-service-resource-group: s205${{ (github.event_name == 'push' || github.event.inputs.instance == 'None') && 'd01' || github.event.inputs.instance }}-swip-rg
+      web-app-name: s205${{ (github.event_name == 'push' || github.event.inputs.instance == 'None') && 'd01' || github.event.inputs.instance }}-wa-proxy-service
+      image-tag: s205d01acr.azurecr.io/dfe-digital-swip-digital-service/proxy-service:${{ github.event.inputs.version-tag }}
       version-endpoint-path: /version.txt

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -131,7 +131,6 @@ jobs:
             -var='moodle_admin_user=${{ vars.MOODLE_ADMIN_USER }}' \
             -var='auth_service_client_id=${{ vars.AUTH_SERVICE_CLIENT_ID }}' \
             -var='auth_service_client_secret=${{ secrets.AUTH_SERVICE_CLIENT_SECRET }}' \
-            -var='one_login_client_id=${{ vars.ONE_LOGIN_CLIENT_ID }}' \
             || export exitcode=$?
 
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Controllers/KeysController.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Controllers/KeysController.cs
@@ -1,0 +1,87 @@
+using System.Security.Cryptography.X509Certificates;
+using Azure.Security.KeyVault.Certificates;
+using Azure.Security.KeyVault.Secrets;
+using Dfe.Sww.Ecf.AuthorizeAccess.Infrastructure.Security.Configuration;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.IdentityModel.Tokens;
+
+[ApiController]
+[Route("api/[controller]")]
+[AllowAnonymous]
+public class KeysController(
+    CertificateClient certClient,
+    SecretClient secretClient,
+    IMemoryCache cache,
+    OneLoginConfiguration oneLoginConfiguration
+) : Controller
+{
+    [HttpGet("onelogin")]
+    [ResponseCache(Duration = 3600)]
+    public async Task<IActionResult> GetOneLoginKeys()
+    {
+        // This method provides an /api/keys/onelogin JWKS endpoint for use with OneLogin
+        // It lists the public keys which are supported for signing JWTs
+        if (cache.TryGetValue<JsonWebKeySet>("OneLoginJWKS", out var jwks))
+        {
+            return Ok(jwks);
+        }
+
+        var versions = certClient
+            .GetPropertiesOfCertificateVersionsAsync(oneLoginConfiguration.CertificateName)
+            .OrderByDescending(p => p.CreatedOn);
+
+        var now = DateTimeOffset.UtcNow;
+        var toInclude = new List<X509Certificate2>();
+
+        // Always include the latest version of the public key
+        var latestMeta = await versions.FirstAsync();
+        toInclude.Add(await FetchCertAsync(latestMeta.Version));
+
+        // Optionally include the previous if within overlap window
+        var prevMeta = await versions.Skip(1).FirstOrDefaultAsync();
+        if (prevMeta?.ExpiresOn?.AddHours(24) > now)
+        {
+            toInclude.Add(await FetchCertAsync(prevMeta.Version));
+        }
+
+        jwks = new JsonWebKeySet();
+
+        foreach(var cert in toInclude)
+        {
+            var rsa = cert.GetRSAPublicKey() ?? throw new InvalidOperationException("Not RSA");
+            var parameters = rsa.ExportParameters(false);
+
+            var n = Base64UrlEncoder.Encode(parameters.Modulus);
+            var e = Base64UrlEncoder.Encode(parameters.Exponent);
+
+            var jwk = new JsonWebKey
+            {
+                Kid = cert.Thumbprint,
+                Kty = JsonWebAlgorithmsKeyTypes.RSA,
+                Use = JsonWebKeyUseNames.Sig,
+                N = n,
+                E = e
+            };
+
+            jwks.Keys.Add(jwk);
+        }        
+
+        cache.Set("OneLoginJWKS", jwks, TimeSpan.FromMinutes(60));
+
+        return Ok(jwks);
+    }
+
+    private async Task<X509Certificate2> FetchCertAsync(string version)
+    {
+        var secret = await secretClient
+            .GetSecretAsync(oneLoginConfiguration.CertificateName, version);
+        var raw = Convert.FromBase64String(secret.Value.Value);
+        
+        return new X509Certificate2(
+            raw,
+            (string?)null,
+            X509KeyStorageFlags.EphemeralKeySet);
+    }
+}

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Infrastructure/Configuration/FeatureFlags.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Infrastructure/Configuration/FeatureFlags.cs
@@ -15,4 +15,5 @@ public class FeatureFlags
     public bool EnableForwardedHeaders { get; set; }
     public bool EnableMsDotNetDataProtectionServices { get; set; }
     public bool EnableOpenIdCertificates { get; set; }
+    public bool EnableOneLoginCertificateRotation { get; set; }
 }

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Infrastructure/Security/CertificateExtensions.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Infrastructure/Security/CertificateExtensions.cs
@@ -21,7 +21,7 @@ public static class KeyVaultCertificateExtensions
             certClient.VaultUri,
             credential ?? new DefaultAzureCredential());
 
-        string secretName    = certWithPolicy.Name!;
+        string secretName = certWithPolicy.Name!;
         string secretVersion = certWithPolicy.Properties.Version!;
 
         KeyVaultSecret secret = 
@@ -31,8 +31,8 @@ public static class KeyVaultCertificateExtensions
         byte[] pfxBytes = Convert.FromBase64String(secret.Value);
         
         return new X509Certificate2(
-            pfxBytes,                      // PFX data
-            (string?)null,                 // no password
+            pfxBytes,                      
+            (string?)null,
             X509KeyStorageFlags.EphemeralKeySet
         );
     }

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Infrastructure/Security/Configuration/OneLoginConfiguration.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Infrastructure/Security/Configuration/OneLoginConfiguration.cs
@@ -4,9 +4,11 @@ public sealed class OneLoginConfiguration
 {
     public const string ConfigurationKey = "OneLogin";
 
-    public string? Url { get; init; }
+    public string Url { get; init; } = "";
 
     public string? ClientId { get; init; }
 
     public string? PrivateKeyPem { get; init; }
+
+    public string? CertificateName { get; init; }
 }

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/appsettings.Azure.json
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/appsettings.Azure.json
@@ -31,7 +31,8 @@
     "EnableHttpStrictTransportSecurity": true,
     "EnableForwardedHeaders": true,
     "EnableMsDotNetDataProtectionServices": true,
-    "EnableOpenIdCertificates": true
+    "EnableOpenIdCertificates": true,
+    "EnableOneLoginCertificateRotation": true
   },   
   "AllowedHosts": "*",
   "KeyVaultUri": "",
@@ -74,7 +75,7 @@
     },
     "OneLogin": {
       "ClientId": "",
-      "PrivateKeyPem": "",
+      "CertificateName": "",
       "Url": ""
     }
 }

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/appsettings.Development.json
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/appsettings.Development.json
@@ -29,7 +29,8 @@
     "EnableHttpStrictTransportSecurity": false,
     "EnableForwardedHeaders": false,
     "EnableMsDotNetDataProtectionServices": false,
-    "EnableOpenIdCertificates": false
+    "EnableOpenIdCertificates": false,
+    "EnableOneLoginCertificateRotation": false
   },    
   "Oidc": {
     "Issuer": "https://localhost:7236",

--- a/apps/moodle-docker/config.php
+++ b/apps/moodle-docker/config.php
@@ -17,7 +17,8 @@ $CFG->dboptions = [
   'dbsocket' => '',
 ];
 
-$host = $_SERVER['HTTP_HOST'] ?? getenv('MOODLE_DOCKER_WEB_HOST') ?? 'localhost';
+# Get host name from Front Door forward header first, then fallback
+$host = $_SERVER['HTTP_X_FORWARDED_HOST'] ?? $_SERVER['HTTP_HOST'] ?? getenv('MOODLE_DOCKER_WEB_HOST') ?? 'localhost';
 if (empty($_SERVER['HTTP_HOST'])) {
   $_SERVER['HTTP_HOST'] = $host;
 }

--- a/terraform/envs/d01/env.tfvars
+++ b/terraform/envs/d01/env.tfvars
@@ -25,3 +25,4 @@ auth_service_feature_flag_overrides = {
   "FEATUREFLAGS__ENABLEDEVELOPEREXCEPTIONPAGE" = "true"
   "FEATUREFLAGS__ENABLESWAGGER"                = "true"
 }
+one_login_client_id = "p4yA1KMFQIoQbqmtntQZPTfdN_I"

--- a/terraform/envs/d02/env.tfvars
+++ b/terraform/envs/d02/env.tfvars
@@ -26,3 +26,5 @@ auth_service_feature_flag_overrides = {
   "FEATUREFLAGS__ENABLEDEVELOPEREXCEPTIONPAGE" = "true"
   "FEATUREFLAGS__ENABLESWAGGER"                = "true"
 }
+# Needs wiring up
+#one_login_client_id = ""

--- a/terraform/modules/web-app/front-door-routes.tf
+++ b/terraform/modules/web-app/front-door-routes.tf
@@ -1,54 +1,51 @@
-# TODO: Re-enable front door integration when Moodle is completely working under the 
-#       default .azurewebsites.net, so no routing intereference.
+resource "azurerm_cdn_frontdoor_endpoint" "front_door_endpoint_web" {
+  cdn_frontdoor_profile_id = var.front_door_profile_web_id
+  name                     = "${var.resource_name_prefix}-fd-endpoint-web-${var.web_app_short_name}"
+  tags                     = var.tags
 
-# resource "azurerm_cdn_frontdoor_endpoint" "front_door_endpoint_web" {
-#   cdn_frontdoor_profile_id = var.front_door_profile_web_id
-#   name                     = "${var.resource_name_prefix}-fd-endpoint-web-${var.web_app_short_name}"
-#   tags                     = var.tags
+  lifecycle {
+    ignore_changes = [tags]
+  }
+}
 
-#   lifecycle {
-#     ignore_changes = [tags]
-#   }
-# }
+resource "azurerm_cdn_frontdoor_origin_group" "front_door_origin_group_web" {
+  cdn_frontdoor_profile_id = var.front_door_profile_web_id
+  name                     = "${var.resource_name_prefix}-fd-origin-group-web-${var.web_app_short_name}"
 
-# resource "azurerm_cdn_frontdoor_origin_group" "front_door_origin_group_web" {
-#   cdn_frontdoor_profile_id = var.front_door_profile_web_id
-#   name                     = "${var.resource_name_prefix}-fd-origin-group-web-${var.web_app_short_name}"
+  health_probe {
+    interval_in_seconds = 60
+    protocol            = "Https"
+    request_type        = "GET"
+    path                = "/health"
+  }
 
-#   health_probe {
-#     interval_in_seconds = 60
-#     protocol            = "Https"
-#     request_type        = "GET"
-#     path                = "/health"
-#   }
+  load_balancing {
+    sample_size                 = 4
+    successful_samples_required = 2
+  }
+}
 
-#   load_balancing {
-#     sample_size                 = 4
-#     successful_samples_required = 2
-#   }
-# }
+resource "azurerm_cdn_frontdoor_origin" "front_door_origin_web" {
+  cdn_frontdoor_origin_group_id  = azurerm_cdn_frontdoor_origin_group.front_door_origin_group_web.id
+  certificate_name_check_enabled = false
+  host_name                      = azurerm_linux_web_app.webapp.default_hostname
+  http_port                      = 80
+  https_port                     = 443
+  origin_host_header             = azurerm_linux_web_app.webapp.default_hostname
+  priority                       = 1
+  weight                         = 1
+  name                           = "${var.resource_name_prefix}-fd-origin-web-${var.web_app_short_name}"
+  enabled                        = true
+}
 
-# resource "azurerm_cdn_frontdoor_origin" "front_door_origin_web" {
-#   cdn_frontdoor_origin_group_id  = azurerm_cdn_frontdoor_origin_group.front_door_origin_group_web.id
-#   certificate_name_check_enabled = false
-#   host_name                      = azurerm_linux_web_app.webapp.default_hostname
-#   http_port                      = 80
-#   https_port                     = 443
-#   origin_host_header             = azurerm_linux_web_app.webapp.default_hostname
-#   priority                       = 1
-#   weight                         = 1
-#   name                           = "${var.resource_name_prefix}-fd-origin-web-${var.web_app_short_name}"
-#   enabled                        = true
-# }
+resource "azurerm_cdn_frontdoor_route" "front_door_route_web" {
+  name                          = "${var.resource_name_prefix}-fd-route-web-${var.web_app_short_name}"
+  cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.front_door_endpoint_web.id
+  cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.front_door_origin_group_web.id
+  cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.front_door_origin_web.id]
 
-# resource "azurerm_cdn_frontdoor_route" "front_door_route_web" {
-#   name                          = "${var.resource_name_prefix}-fd-route-web-${var.web_app_short_name}"
-#   cdn_frontdoor_endpoint_id     = azurerm_cdn_frontdoor_endpoint.front_door_endpoint_web.id
-#   cdn_frontdoor_origin_group_id = azurerm_cdn_frontdoor_origin_group.front_door_origin_group_web.id
-#   cdn_frontdoor_origin_ids      = [azurerm_cdn_frontdoor_origin.front_door_origin_web.id]
-
-#   forwarding_protocol    = "MatchRequest"
-#   https_redirect_enabled = true
-#   patterns_to_match      = ["/*"]
-#   supported_protocols    = ["Http", "Https"]
-# }
+  forwarding_protocol    = "MatchRequest"
+  https_redirect_enabled = true
+  patterns_to_match      = ["/*"]
+  supported_protocols    = ["Http", "Https"]
+}

--- a/terraform/modules/web-app/web-app.tf
+++ b/terraform/modules/web-app/web-app.tf
@@ -16,16 +16,12 @@ resource "azurerm_linux_web_app" "webapp" {
     ftps_state             = "Disabled"
     minimum_tls_version    = "1.3"
 
-    # TODO: Re-enable front-door only integration when Moodle is completely working under the 
-    #       default .azurewebsites.net domain, so no routing intereference.
+    ip_restriction_default_action = "Deny"
 
-    #ip_restriction_default_action = "Deny"
-    ip_restriction_default_action = "Allow"
-
-    # ip_restriction {
-    #   name        = "Access from Front Door"
-    #   service_tag = "AzureFrontDoor.Backend"
-    # }
+    ip_restriction {
+      name        = "Access from Front Door"
+      service_tag = "AzureFrontDoor.Backend"
+    }
 
     container_registry_use_managed_identity = true
     application_stack {

--- a/terraform/proxy-service.tf
+++ b/terraform/proxy-service.tf
@@ -6,7 +6,7 @@ module "proxy_service" {
   resource_group            = module.stack.resource_group_name
   resource_name_prefix      = var.resource_name_prefix
   web_app_name              = "${var.resource_name_prefix}-wa-proxy-service"
-  web_app_short_name        = "proxy-service"
+  web_app_short_name        = "wa-proxy-service"
   docker_image_name         = "dfe-digital/nothing:latest"
   front_door_profile_web_id = module.stack.front_door_profile_web_id
   subnet_webapps_id         = module.stack.subnet_services_id

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -170,7 +170,7 @@ variable "one_login_oidc_url" {
 }
 
 variable "one_login_client_id" {
-  description = "One Login client ID"
+  description = "The client ID for one login (non-secret)"
   type        = string
 }
 


### PR DESCRIPTION
- Deployment workflows are now parameterised to accept image version tag to deploy
- OneLogin integration environment is set up for d01 (https://admin.sign-in.service.gov.uk/)
- FrontDoor integration re-enabled - apps now use the Front Door generated URLs
- Implemented JWKS endpoint for auth service (/api/keys/onelogin) to aupport autonomous and automatic key refresh with 24 hour overlap between previous and new key (both supported at same time within window)
- Deployed and serves in Azure, but OneLogin needs end to end testing

Next steps: Moodle / Onelogin integration and front-end deployment