### PR TITLE
SWIP-607 Ability to toggle Gov UK theming and fix Moodle host URL issue

### DIFF
--- a/apps/moodle-docker/config.php
+++ b/apps/moodle-docker/config.php
@@ -19,11 +19,10 @@ $CFG->dboptions = [
 
 # Get host name from Front Door forward header first, then fallback
 $host = $_SERVER['HTTP_X_FORWARDED_HOST'] ?? $_SERVER['HTTP_HOST'] ?? getenv('MOODLE_DOCKER_WEB_HOST') ?? 'localhost';
-if (empty($_SERVER['HTTP_HOST'])) {
-  $_SERVER['HTTP_HOST'] = $host;
-}
+$_SERVER['HTTP_HOST'] = $host;
 $httpOrS = '';
 if (getenv('MOODLE_DOCKER_SSL_TERMINATION') === 'true') {
+  $CFG->sslproxy = true;
   $CFG->sslproxy = true;
   $httpOrS = 's';
 }
@@ -43,7 +42,9 @@ $CFG->admin = getenv('MOODLE_ADMIN_USER');
 
 $CFG->directorypermissions = 02777;
 
-$CFG->theme = 'govuk';
+if (getenv('MOODLE_SWITCH_OFF_GOVUK_THEMING') !== 'true') {
+  $CFG->theme = 'govuk'; 
+}
 
 // The Moodle instances should NOT run their own cron jobs
 $CFG->cronclionly = true;

--- a/terraform/envs/d01/env.tfvars
+++ b/terraform/envs/d01/env.tfvars
@@ -26,3 +26,6 @@ auth_service_feature_flag_overrides = {
   "FEATUREFLAGS__ENABLESWAGGER"                = "true"
 }
 one_login_client_id = "p4yA1KMFQIoQbqmtntQZPTfdN_I"
+moodle_app_settings = {
+  "MOODLE_SWITCH_OFF_GOVUK_THEMING" = "false"
+}

--- a/terraform/envs/d02/env.tfvars
+++ b/terraform/envs/d02/env.tfvars
@@ -27,4 +27,7 @@ auth_service_feature_flag_overrides = {
   "FEATUREFLAGS__ENABLESWAGGER"                = "true"
 }
 # Needs wiring up
-#one_login_client_id = ""
+one_login_client_id = ""
+moodle_app_settings = {
+  "MOODLE_SWITCH_OFF_GOVUK_THEMING" = "true"
+}

--- a/terraform/moodle-web-apps.tf
+++ b/terraform/moodle-web-apps.tf
@@ -37,7 +37,7 @@ module "web_app_moodle" {
   service_plan_id           = module.stack.moodle_service_plan_id
   tags                      = local.common_tags
 
-  app_settings = {
+  app_settings = merge({
     "ENVIRONMENT"                         = var.environment
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
     "IS_CRON_JOB_ONLY"                    = "false"
@@ -55,7 +55,7 @@ module "web_app_moodle" {
     "MOODLE_ADMIN_PASSWORD"               = var.moodle_admin_password
     "MOODLE_ADMIN_EMAIL"                  = var.moodle_admin_email
     DOCKER_ENABLE_CI                      = "false" # Github will control CI, not Azure
-  }
+  }, var.moodle_app_settings)
 
   depends_on = [
     azurerm_postgresql_flexible_server_database.moodle_db
@@ -85,7 +85,7 @@ module "web_app_moodle_cron" {
   # This is because one installation webapp can service multiple moodle
   # instances, the only difference being the database name.
 
-  app_settings = {
+  app_settings = merge({
     "ENVIRONMENT"                         = var.environment
     "IS_CRON_JOB_ONLY"                    = "true"
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE" = "false"
@@ -103,7 +103,7 @@ module "web_app_moodle_cron" {
     "MOODLE_ADMIN_PASSWORD"               = var.moodle_admin_password
     "MOODLE_ADMIN_EMAIL"                  = var.moodle_admin_email
     DOCKER_ENABLE_CI                      = "false" # Github will control CI, not Azure
-  }
+  }, var.moodle_app_settings)
 
   depends_on = [
     azurerm_postgresql_flexible_server_database.moodle_db

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -175,6 +175,12 @@ variable "one_login_client_id" {
 }
 
 variable "auth_service_feature_flag_overrides" {
-  description = "Auth service feature flag overrides"
+  description = "Environment specific auth service feature flag overrides"
   type        = map(string)
+}
+
+variable "moodle_app_settings" {
+  description = "Environment specific Moodle app settings"
+  type        = map(string)
+  default     = {}
 }


### PR DESCRIPTION
In Terraform, introduce a new MOODLE_SWITCH_OFF_GOVUK_THEMING ap setting which allows the Gov UK theming to be toggled on and off. Also fixed a continuous redirect issue with $_SERVER['HTTP_HOST'] - always give preference to the front door $_SERVER['HTTP_X_FORWARDED_HOST'] header if provided.