### PR TITLE
SWIP-576 - add user content changes and eligibility info page

### DIFF
--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/ConfirmAccountDetailsPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/ConfirmAccountDetailsPageTests.cs
@@ -128,6 +128,7 @@ public class ConfirmAccountDetailsShould : ManageAccountsPageTestBase<ConfirmAcc
         response!.Url.Should().Be("/manage-accounts");
 
         MockCreateAccountJourneyService.Verify(x => x.GetAccountDetails(), Times.Once);
+        MockCreateAccountJourneyService.Verify(x => x.SetExternalUserId(1), Times.Once);
         MockCreateAccountJourneyService.Verify(x => x.CompleteJourneyAsync(), Times.Once);
         MockMoodleServiceClient.Verify(
             x => x.User.CreateUserAsync(MoqHelpers.ShouldBeEquivalentTo(createUserRequest)),

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityInformationPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityInformationPageTests.cs
@@ -1,0 +1,33 @@
+using Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
+using Dfe.Sww.Ecf.Frontend.Test.UnitTests.Helpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Xunit;
+
+namespace Dfe.Sww.Ecf.Frontend.Test.UnitTests.Pages.ManageAccounts;
+
+public class EligibilityInformationPageTests : ManageAccountsPageTestBase<EligibilityInformation>
+{
+    private EligibilityInformation Sut { get; }
+
+    public EligibilityInformationPageTests()
+    {
+        Sut = new EligibilityInformation(
+            new FakeLinkGenerator()
+        );
+    }
+
+    [Fact]
+    public void OnGet_WhenCalled_LoadsTheView()
+    {
+        // Act
+        var result = Sut.OnGet();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+
+        Sut.BackLinkPath.Should().Be("/manage-accounts/select-account-type");
+
+        VerifyAllNoOtherCalls();
+    }
+}

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/SelectAccountTypePageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/SelectAccountTypePageTests.cs
@@ -1,0 +1,122 @@
+using Dfe.Sww.Ecf.Frontend.Models;
+using Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
+using Dfe.Sww.Ecf.Frontend.Test.UnitTests.Helpers;
+using Dfe.Sww.Ecf.Frontend.Validation;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Moq;
+using Xunit;
+
+namespace Dfe.Sww.Ecf.Frontend.Test.UnitTests.Pages.ManageAccounts;
+
+public class SelectAccountTypePageTests : ManageAccountsPageTestBase<SelectAccountType>
+{
+    private SelectAccountType Sut { get; }
+
+    public SelectAccountTypePageTests()
+    {
+        Sut = new SelectAccountType(
+            MockCreateAccountJourneyService.Object,
+            new FakeLinkGenerator(),
+            new SelectAccountTypeValidator()
+        );
+    }
+
+    [Fact]
+    public void OnGet_WhenCalled_LoadsTheView()
+    {
+        // Act
+        var result = Sut.OnGet();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+
+        Sut.IsStaff.Should().BeNull();
+        Sut.EditAccountId.Should().BeNull();
+        Sut.BackLinkPath.Should().Be("/manage-accounts");
+
+        MockCreateAccountJourneyService.Verify(x => x.GetIsStaff(), Times.Once);
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public void OnGetNew_WhenCalled_ResetsModelAndRedirectsToSelectAccountType()
+    {
+        // Act
+        var result = Sut.OnGetNew();
+
+        // Assert
+        result.Should().BeOfType<RedirectResult>();
+        result.Url.Should().Be("/manage-accounts/select-account-type");
+
+        MockCreateAccountJourneyService.Verify(x => x.ResetCreateAccountJourneyModel(), Times.Once);
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task OnPostAsync_WhenCalledWithNullIsStaff_ReturnsErrorsAndRedirectsToSelectAccountType()
+    {
+        // Arrange
+        Sut.IsStaff = null;
+
+        // Act
+        var result = await Sut.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+
+        var modelState = Sut.ModelState;
+        var modelStateKeys = modelState.Keys.ToList();
+        modelStateKeys.Count.Should().Be(1);
+        modelStateKeys.Should().Contain("IsStaff");
+        modelState["IsStaff"]!.Errors.Count.Should().Be(1);
+        modelState["IsStaff"]!.Errors[0].ErrorMessage.Should().Be("Select the type of user you want to add");
+
+        Sut.BackLinkPath.Should().Be("/manage-accounts");
+
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task OnPostAsync_WhenCalledWithIsStaffTrue_RedirectsToSelectUseCase()
+    {
+        // Arrange
+        Sut.IsStaff = true;
+
+        // Act
+        var result = await Sut.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<RedirectResult>();
+        var redirectResult = result as RedirectResult;
+        redirectResult.Should().NotBeNull();
+        redirectResult!.Url.Should().Be("/manage-accounts/select-use-case");
+
+        MockCreateAccountJourneyService.Verify(x => x.SetIsStaff(true), Times.Once);
+
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task OnPostAsync_WhenCalledWithIsStaffFalse_RedirectsToEligibilityInformation()
+    {
+        // Arrange
+        Sut.IsStaff = false;
+
+        // Act
+        var result = await Sut.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<RedirectResult>();
+        var redirectResult = result as RedirectResult;
+        redirectResult.Should().NotBeNull();
+        redirectResult!.Url.Should().Be("/manage-accounts/eligibility-information");
+
+        MockCreateAccountJourneyService.Verify(x => x.SetIsStaff(false), Times.Once);
+        MockCreateAccountJourneyService.Verify(x => x.SetAccountTypes(new List<AccountType>
+            { AccountType.EarlyCareerSocialWorker }), Times.Once);
+
+        VerifyAllNoOtherCalls();
+    }
+}

--- a/apps/user-management/apps/frontend/Dfe.Sww.Ecf.Frontend.csproj
+++ b/apps/user-management/apps/frontend/Dfe.Sww.Ecf.Frontend.csproj
@@ -16,7 +16,7 @@
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="11.9.2" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
-        <PackageReference Include="GovUk.Frontend.AspNetCore" Version="2.0.1"/>
+        <PackageReference Include="GovUk.Frontend.AspNetCore" Version="2.8.1" />
         <PackageReference Include="JetBrains.Annotations" Version="2024.2.0" />
         <PackageReference Include="Joonasw.AspNetCore.SecurityHeaders" Version="5.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityInformation.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityInformation.cshtml
@@ -23,7 +23,7 @@
 
             <p>Make sure you have checked this information before you get started.</p>
             @* TODO: Link to ElibibilitySwe page after SWIP-577 *@
-            <govuk-button-link href="">Continue</govuk-button-link>
+            <govuk-button-link href="@LinkGenerator.AddAccountDetails()">Continue</govuk-button-link>
         </div>
     </div>
 </div>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityInformation.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityInformation.cshtml
@@ -1,0 +1,29 @@
+@page
+@model Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts.EligibilityInformation
+
+@{
+    Model.Title = "Before you begin";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Before you begin</h1>
+        <div class="govuk-body">
+            <p>Employers receive grant funding for eligible social workers who take part in the programme.</p>
+
+            <p>We will ask some questions to make sure the social worker meets the eligibility criteria.</p>
+
+            <p>You will need to confirm that the social worker:</p>
+
+            <ul class="govuk-list govuk-list--bullet">
+                <li>is registered with Social Work England</li>
+                <li>currently works in statutory child and family social work in England</li>
+                <li>has completed their social work qualification within the last 3 years</li>
+            </ul>
+
+            <p>Make sure you have checked this information before you get started.</p>
+            @* TODO: Link to ElibibilitySwe page after SWIP-577 *@
+            <govuk-button-link href="">Continue</govuk-button-link>
+        </div>
+    </div>
+</div>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityInformation.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityInformation.cshtml.cs
@@ -1,0 +1,19 @@
+using Dfe.Sww.Ecf.Frontend.Authorisation;
+using Dfe.Sww.Ecf.Frontend.Pages.Shared;
+using Dfe.Sww.Ecf.Frontend.Routing;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
+
+/// <summary>
+/// Eligibility Information View Model
+/// </summary>
+[AuthorizeRoles(RoleType.Coordinator)]
+public class EligibilityInformation(EcfLinkGenerator linkGenerator) : BasePageModel
+{
+    public PageResult OnGet()
+    {
+        BackLinkPath = linkGenerator.SelectAccountType();
+        return Page();
+    }
+}

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml
@@ -18,8 +18,8 @@
                             @(Model.EditAccountId is not null ? "What is their role?" : "Who do you want to add?")
                         </govuk-radios-fieldset-legend>
 
-                        <govuk-radios-item value="@false">An early career social worker taking part in the PQP programme</govuk-radios-item>
-                        <govuk-radios-item value="@true">A staff member supporting the PQP programme</govuk-radios-item>
+                        <govuk-radios-item value="@false">An early career social worker taking part in the programme</govuk-radios-item>
+                        <govuk-radios-item value="@true">A staff member supporting the programme</govuk-radios-item>
                     </govuk-radios-fieldset>
                 </govuk-radios>
             </div>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml
@@ -1,30 +1,26 @@
 ﻿@page "{id:Guid?}"
-@using GovUk.Frontend.AspNetCore.TagHelpers
 @model SelectAccountType
 
 @{
-    Model.Title = "Choose account type";
+    Model.Title = "Who do you want to add?";
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
         <form method="post" asp-page-handler="@(Model.EditAccountId is not null ? "Edit" : "")">
-            <div class="govuk-form-group">
+            <govuk-radios asp-for="IsStaff">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+                        @(Model.EditAccountId is not null ? "What is their role?" : "Who do you want to add?")
+                    </govuk-radios-fieldset-legend>
 
-                <govuk-radios asp-for="IsStaff">
-                    <govuk-radios-fieldset>
-                        <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
-                            @(Model.EditAccountId is not null ? "What is their role?" : "Who do you want to add?")
-                        </govuk-radios-fieldset-legend>
+                    <govuk-radios-item value="@false">An early career social worker taking part in the programme</govuk-radios-item>
+                    <govuk-radios-item value="@true">A staff member supporting the programme</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
 
-                        <govuk-radios-item value="@false">An early career social worker taking part in the programme</govuk-radios-item>
-                        <govuk-radios-item value="@true">A staff member supporting the programme</govuk-radios-item>
-                    </govuk-radios-fieldset>
-                </govuk-radios>
-            </div>
-
-            <button type="submit" class="govuk-button">Continue</button>
+            <govuk-button type="submit">Continue</govuk-button>
         </form>
 
     </div>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml.cs
@@ -16,7 +16,7 @@ public class SelectAccountType(
 ) : BasePageModel
 {
     [BindProperty]
-    [Required(ErrorMessage = "Select who you want to add")]
+    [Required(ErrorMessage = "Select the type of user you want to add")]
     public bool? IsStaff { get; set; }
 
     public Guid? EditAccountId { get; set; }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml.cs
@@ -49,6 +49,6 @@ public class SelectAccountType(
             return Redirect(linkGenerator.SelectUseCase());
         }
         createAccountJourneyService.SetAccountTypes([AccountType.EarlyCareerSocialWorker]);
-        return Redirect(linkGenerator.AddAccountDetails());
+        return Redirect(linkGenerator.EligibilityInformation());
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml.cs
@@ -1,9 +1,11 @@
 using System.ComponentModel.DataAnnotations;
 using Dfe.Sww.Ecf.Frontend.Authorisation;
+using Dfe.Sww.Ecf.Frontend.Extensions;
 using Dfe.Sww.Ecf.Frontend.Models;
 using Dfe.Sww.Ecf.Frontend.Pages.Shared;
 using Dfe.Sww.Ecf.Frontend.Routing;
 using Dfe.Sww.Ecf.Frontend.Services.Journeys.Interfaces;
+using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
@@ -12,11 +14,11 @@ namespace Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
 [AuthorizeRoles(RoleType.Coordinator)]
 public class SelectAccountType(
     ICreateAccountJourneyService createAccountJourneyService,
-    EcfLinkGenerator linkGenerator
+    EcfLinkGenerator linkGenerator,
+    IValidator<SelectAccountType> validator
 ) : BasePageModel
 {
     [BindProperty]
-    [Required(ErrorMessage = "Select the type of user you want to add")]
     public bool? IsStaff { get; set; }
 
     public Guid? EditAccountId { get; set; }
@@ -34,10 +36,12 @@ public class SelectAccountType(
         return Page();
     }
 
-    public IActionResult OnPost()
+    public async Task<IActionResult> OnPostAsync()
     {
-        if (!ModelState.IsValid)
+        var validationResult = await validator.ValidateAsync(this);
+        if (IsStaff is null || !validationResult.IsValid)
         {
+            validationResult.AddToModelState(ModelState);
             BackLinkPath = linkGenerator.ManageAccounts();
             return Page();
         }

--- a/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
+++ b/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
@@ -73,6 +73,8 @@ public abstract class EcfLinkGenerator(
 
     public string AddExistingUser() => GetRequiredPathByPage("/ManageAccounts/AddExistingUser");
 
+    public string EligibilityInformation() => GetRequiredPathByPage("/ManageAccounts/EligibilityInformation");
+
     protected abstract string GetRequiredPathByPage(
         string page,
         string? handler = null,

--- a/apps/user-management/apps/frontend/Validation/SelectAccountTypeValidator.cs
+++ b/apps/user-management/apps/frontend/Validation/SelectAccountTypeValidator.cs
@@ -1,0 +1,14 @@
+using Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
+using FluentValidation;
+
+namespace Dfe.Sww.Ecf.Frontend.Validation;
+
+public class SelectAccountTypeValidator : AbstractValidator<SelectAccountType>
+{
+    public SelectAccountTypeValidator()
+    {
+        RuleFor(model => model.IsStaff)
+            .NotEmpty()
+            .WithMessage("Select the type of user you want to add");
+    }
+}


### PR DESCRIPTION
- Error message and radio options text updated:
![image](https://github.com/user-attachments/assets/fb0d947a-9c15-41dc-a8c5-07f49105d589)
- Adds new Eligibility information page and links to it when selecting to add a new ECSW:
![image](https://github.com/user-attachments/assets/681253c4-83a6-4653-a170-112a05928455)
    - Continue button currently links to AddAccountDetails until SWIP-577 is done
- Bumps GovUk.Frontend.AspNetCore to 2.8.1
- Adds missing unit tests for SelectAccountType page
- Fixed unit test that was broken due to SWIP-335 changes
