### PR TITLE
SWIP-577 - Social Work England eligibility check page

### DIFF
--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilitySocialWorkEnglandPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilitySocialWorkEnglandPageTests.cs
@@ -1,0 +1,110 @@
+using Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
+using Dfe.Sww.Ecf.Frontend.Test.UnitTests.Helpers;
+using Dfe.Sww.Ecf.Frontend.Validation;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Moq;
+using Xunit;
+
+namespace Dfe.Sww.Ecf.Frontend.Test.UnitTests.Pages.ManageAccounts;
+
+public class EligibilitySocialWorkEnglandPageTests : ManageAccountsPageTestBase<EligibilitySocialWorkEngland>
+{
+    private EligibilitySocialWorkEngland Sut { get; }
+
+    public EligibilitySocialWorkEnglandPageTests()
+    {
+        Sut = new EligibilitySocialWorkEngland(
+            MockCreateAccountJourneyService.Object,
+            new FakeLinkGenerator(),
+            new EligibilitySocialWorkEnglandValidator()
+        );
+    }
+
+    [Fact]
+    public void OnGet_WhenCalled_LoadsTheView()
+    {
+        // Act
+        var result = Sut.OnGet();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+
+        Sut.BackLinkPath.Should().Be("/manage-accounts/eligibility-information");
+
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task
+        OnPostAsync_WhenCalledWithNullIsRegisteredWithSocialWorkEngland_ReturnsErrorsAndRedirectsToEligibilitySocialWorkEngland()
+    {
+        // Arrange
+        Sut.IsRegisteredWithSocialWorkEngland = null;
+
+        // Act
+        var result = await Sut.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+
+        var modelState = Sut.ModelState;
+        var modelStateKeys = modelState.Keys.ToList();
+        modelStateKeys.Count.Should().Be(1);
+        modelStateKeys.Should().Contain("IsRegisteredWithSocialWorkEngland");
+        modelState["IsRegisteredWithSocialWorkEngland"]!.Errors.Count.Should().Be(1);
+        modelState["IsRegisteredWithSocialWorkEngland"]!.Errors[0].ErrorMessage.Should()
+            .Be("Select if the user is registered with Social Work England");
+
+        Sut.BackLinkPath.Should().Be("/manage-accounts/eligibility-information");
+
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task
+        OnPostAsync_WhenCalledWithIsRegisteredWithSocialWorkEnglandTrue_RedirectsToEligibilityStatutoryWork()
+    {
+        // Arrange
+        Sut.IsRegisteredWithSocialWorkEngland = true;
+
+        // Act
+        var result = await Sut.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<RedirectResult>();
+        var redirectResult = result as RedirectResult;
+        redirectResult.Should().NotBeNull();
+        // TODO: Update this redirect assertion in SWIP-579
+        // redirectResult!.Url.Should().Be("/manage-accounts/eligibility-statutory-work");
+        redirectResult!.Url.Should().Be("/manage-accounts/add-account-details");
+
+        MockCreateAccountJourneyService.Verify(x => x.SetIsRegisteredWithSocialWorkEngland(true), Times.Once);
+
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task
+        OnPostAsync_WhenCalledWithIsRegisteredWithSocialWorkEnglandFalse_RedirectsToEligibilityDropoutPage()
+    {
+        // Arrange
+        Sut.IsRegisteredWithSocialWorkEngland = false;
+
+        // Act
+        var result = await Sut.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<RedirectResult>();
+        var redirectResult = result as RedirectResult;
+        redirectResult.Should().NotBeNull();
+        // TODO: Update this redirect assertion in SWIP-590
+        // redirectResult!.Url.Should().Be("/manage-accounts/eligibility-dropout");
+        redirectResult!.Url.Should().Be("/manage-accounts/add-account-details");
+
+        MockCreateAccountJourneyService.Verify(x => x.SetIsRegisteredWithSocialWorkEngland(false), Times.Once);
+
+        VerifyAllNoOtherCalls();
+    }
+}

--- a/apps/user-management/apps/frontend/Models/CreateAccountJourneyModel.cs
+++ b/apps/user-management/apps/frontend/Models/CreateAccountJourneyModel.cs
@@ -15,6 +15,8 @@ public class CreateAccountJourneyModel
 
     public int? ExternalUserId { get; set; }
 
+    public bool? IsRegisteredWithSocialWorkEngland { get; set; }
+
     public Account ToAccount()
     {
         return new Account

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/AddAccountDetails.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/AddAccountDetails.cshtml
@@ -28,22 +28,21 @@
 
                 @if (!Model.IsStaff)
                 {
-                    <govuk-input-label class="govuk-label">Social Work England registration number (optional)</govuk-input-label>
-                    <govuk-input-hint class="govuk-hint">
-                        <p>
-                            You need to provide a Social Work England registration number in order to receive payments from the Department for
-                            Education for this account. You can
-                            <a href="https://www.socialworkengland.org.uk/" target="_blank">look up the registration number</a>
-                            on the Social Work England website (opens in a new window).
-                        </p>
-                        <p class="govuk-!-margin-bottom-0">
-                            If you don't know the registration number yet, you can add it later. Your
-                            organisation will not receive any Post qualifying pathway (PQP) funding for this account until the registration number
-                            is provided.
-                        </p>
-                    </govuk-input-hint>
                     <govuk-input asp-for="SocialWorkEnglandNumber" spellcheck="false" type="number" input-class="govuk-!-width-one-third">
-                        <govuk-input-label></govuk-input-label>
+                        <govuk-input-label class="govuk-label">Social Work England registration number (optional)</govuk-input-label>
+                        <govuk-input-hint class="govuk-hint">
+                            <p>
+                                You need to provide a Social Work England registration number in order to receive payments from the Department for
+                                Education for this account. You can
+                                <a href="https://www.socialworkengland.org.uk/" target="_blank">look up the registration number</a>
+                                on the Social Work England website (opens in a new window).
+                            </p>
+                            <p class="govuk-!-margin-bottom-0">
+                                If you don't know the registration number yet, you can add it later. Your
+                                organisation will not receive any Post qualifying pathway (PQP) funding for this account until the registration number
+                                is provided.
+                            </p>
+                        </govuk-input-hint>
                         <govuk-input-error-message/>
                     </govuk-input>
                 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityInformation.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityInformation.cshtml
@@ -22,8 +22,7 @@
             </ul>
 
             <p>Make sure you have checked this information before you get started.</p>
-            @* TODO: Link to ElibibilitySwe page after SWIP-577 *@
-            <govuk-button-link href="@LinkGenerator.AddAccountDetails()">Continue</govuk-button-link>
+            <govuk-button-link href="@LinkGenerator.EligibilitySocialWorkEngland()">Continue</govuk-button-link>
         </div>
     </div>
 </div>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml
@@ -1,0 +1,25 @@
+@page
+@model Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts.EligibilitySocialWorkEngland
+
+@{
+    Model.Title = "Are they registered with Social Work England?";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form method="post">
+            <govuk-radios asp-for="IsRegisteredWithSocialWorkEngland">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">
+                        Are they registered with Social Work England?
+                    </govuk-radios-fieldset-legend>
+
+                    <govuk-radios-item value="@true">Yes</govuk-radios-item>
+                    <govuk-radios-item value="@false">No</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml.cs
@@ -31,7 +31,7 @@ public class EligibilitySocialWorkEngland(ICreateAccountJourneyService createAcc
         if (IsRegisteredWithSocialWorkEngland is null || !validationResult.IsValid)
         {
             validationResult.AddToModelState(ModelState);
-            BackLinkPath = linkGenerator.ManageAccounts();
+            BackLinkPath = linkGenerator.EligibilityInformation();
             return Page();
         }
 

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml.cs
@@ -10,7 +10,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 namespace Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
 
 /// <summary>
-/// Eligibility Information View Model
+/// Eligibility Social Work England View Model
 /// </summary>
 [AuthorizeRoles(RoleType.Coordinator)]
 public class EligibilitySocialWorkEngland(ICreateAccountJourneyService createAccountJourneyService, EcfLinkGenerator linkGenerator, IValidator<EligibilitySocialWorkEngland> validator)

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml.cs
@@ -1,0 +1,47 @@
+using Dfe.Sww.Ecf.Frontend.Authorisation;
+using Dfe.Sww.Ecf.Frontend.Extensions;
+using Dfe.Sww.Ecf.Frontend.Pages.Shared;
+using Dfe.Sww.Ecf.Frontend.Routing;
+using Dfe.Sww.Ecf.Frontend.Services.Journeys.Interfaces;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
+
+/// <summary>
+/// Eligibility Information View Model
+/// </summary>
+[AuthorizeRoles(RoleType.Coordinator)]
+public class EligibilitySocialWorkEngland(ICreateAccountJourneyService createAccountJourneyService, EcfLinkGenerator linkGenerator, IValidator<EligibilitySocialWorkEngland> validator)
+    : BasePageModel
+{
+    [BindProperty]
+    public bool? IsRegisteredWithSocialWorkEngland { get; set; }
+
+    public PageResult OnGet()
+    {
+        BackLinkPath = linkGenerator.EligibilityInformation();
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var validationResult = await validator.ValidateAsync(this);
+        if (IsRegisteredWithSocialWorkEngland is null || !validationResult.IsValid)
+        {
+            validationResult.AddToModelState(ModelState);
+            BackLinkPath = linkGenerator.ManageAccounts();
+            return Page();
+        }
+
+        createAccountJourneyService.SetIsRegisteredWithSocialWorkEngland(IsRegisteredWithSocialWorkEngland);
+
+        if (IsRegisteredWithSocialWorkEngland is false)
+        {
+            return Page(); // TODO: Redirect to drop out page in SWIP-590
+        }
+
+        return Redirect(linkGenerator.AddAccountDetails()); // TODO: Redirect to statutory work page in SWIP-579
+    }
+}

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml.cs
@@ -39,7 +39,7 @@ public class EligibilitySocialWorkEngland(ICreateAccountJourneyService createAcc
 
         if (IsRegisteredWithSocialWorkEngland is false)
         {
-            return Page(); // TODO: Redirect to drop out page in SWIP-590
+            return Redirect(linkGenerator.AddAccountDetails()); // TODO: Redirect to drop out page in SWIP-590
         }
 
         return Redirect(linkGenerator.AddAccountDetails()); // TODO: Redirect to statutory work page in SWIP-579

--- a/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
+++ b/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
@@ -75,6 +75,8 @@ public abstract class EcfLinkGenerator(
 
     public string EligibilityInformation() => GetRequiredPathByPage("/ManageAccounts/EligibilityInformation");
 
+    public string EligibilitySocialWorkEngland() => GetRequiredPathByPage("/ManageAccounts/EligibilitySocialWorkEngland");
+
     protected abstract string GetRequiredPathByPage(
         string page,
         string? handler = null,

--- a/apps/user-management/apps/frontend/Services/Journeys/CreateAccountJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/CreateAccountJourneyService.cs
@@ -86,6 +86,13 @@ public class CreateAccountJourneyService(
         SetCreateAccountJourneyModel(createAccountJourneyModel);
     }
 
+    public void SetIsRegisteredWithSocialWorkEngland(bool? isRegisteredWithSocialWorkEngland)
+    {
+        var createAccountJourneyModel = GetCreateAccountJourneyModel();
+        createAccountJourneyModel.IsRegisteredWithSocialWorkEngland = isRegisteredWithSocialWorkEngland;
+        SetCreateAccountJourneyModel(createAccountJourneyModel);
+    }
+
     public void ResetCreateAccountJourneyModel()
     {
         Session.Remove(CreateAccountSessionKey);

--- a/apps/user-management/apps/frontend/Services/Journeys/Interfaces/ICreateAccountJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/Interfaces/ICreateAccountJourneyService.cs
@@ -16,7 +16,10 @@ public interface ICreateAccountJourneyService
     void SetAccountTypes(IList<AccountType> accountTypes);
 
     void SetIsStaff(bool? isStaff);
+
     void SetExternalUserId(int? externalUserId);
+
+    void SetIsRegisteredWithSocialWorkEngland(bool? isRegisteredWithSocialWorkEngland);
 
     Task<Account> CompleteJourneyAsync();
 

--- a/apps/user-management/apps/frontend/Validation/EligibilitySocialWorkEnglandValidator.cs
+++ b/apps/user-management/apps/frontend/Validation/EligibilitySocialWorkEnglandValidator.cs
@@ -1,0 +1,14 @@
+using Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
+using FluentValidation;
+
+namespace Dfe.Sww.Ecf.Frontend.Validation;
+
+public class EligibilitySocialWorkEnglandValidator : AbstractValidator<EligibilitySocialWorkEngland>
+{
+    public EligibilitySocialWorkEnglandValidator()
+    {
+        RuleFor(model => model.IsRegisteredWithSocialWorkEngland)
+            .NotEmpty()
+            .WithMessage("Select if the user is registered with Social Work England");
+    }
+}


### PR DESCRIPTION
- Adds new SWE eligibility check page after eligibility information page
![image](https://github.com/user-attachments/assets/183068cc-9aa3-4530-a62f-44443fb2280f)
    - Answering yes or no will currently take you to the `AddAccountDetails` page until SWIP-579 and SWIP-590 are done to handle those routes.
- Adds error state for new SWE eligibility check page
![image](https://github.com/user-attachments/assets/7f56dc36-8dd4-4cd2-9d49-e87f95795ba3)
- Fixes rendering/DOM error on `AddAccountDetails` page