### PR TITLE
SWIP-584 Integrate Moodle web service setup with build and deployment workflows

### DIFF
--- a/apps/auth-service/Dfe.Sww.Ecf/entry-point.sh
+++ b/apps/auth-service/Dfe.Sww.Ecf/entry-point.sh
@@ -16,5 +16,9 @@ export CONNECTIONSTRINGS__DEFAULTCONNECTION="$(
   sed "s|\$\[DB_REPLACE_PASSWORD\]|${DB_PASSWORD}|g"
 )"
 
+# Support SSH for troubleshooting
+echo "Starting SSH..."
+/usr/sbin/sshd
+
 # Exec the main process passed to us (whatever is specified in CMD)
 exec "$@"

--- a/apps/moodle-apps-azure/entry-point.sh
+++ b/apps/moodle-apps-azure/entry-point.sh
@@ -23,6 +23,22 @@ else
     echo "This will be a full Moodle instance..."
 fi
 
+cd /var/www/html/public
+if [[ "$MOODLE_SWITCH_OFF_OAUTH" == 'true' ]]; then
+    echo "Switching off OAuth..."
+    echo "Disabling oidc authentication method in Moodle config..."
+    su -s /bin/sh www-data -c 'moosh auth-manage disable oidc'
+    echo "Enabling email-based self-registration..."
+    su -s /bin/sh www-data -c 'moosh auth-manage enable email'
+else
+    echo "Switching on OAuth..."
+    echo "Enabling oidc authentication method in Moodle config..."
+    su -s /bin/sh www-data -c 'moosh auth-manage enable oidc'
+    echo "Disabling email-based self-registration..."
+    su -s /bin/sh www-data -c 'moosh auth-manage disable email'
+fi
+su -s /bin/sh www-data -c 'php admin/cli/purge_caches.php'
+
 # exec so Apache gets PID 1 and handles signals cleanly
 echo "Starting Apache..."
 exec apache2-foreground

--- a/apps/moodle-apps-azure/maintain-moodle.sh
+++ b/apps/moodle-apps-azure/maintain-moodle.sh
@@ -71,6 +71,18 @@ EOF
 fi
 
 if [ $? -eq 0 ]; then
+    echo "Last successful install entry: $LAST_SUCCESS"
+    echo "Now running web service setup..."
+
+    cp /app/setup_moodle_webservice.php $WEB_SERVICE_SETUP_FILE
+    su -s /bin/sh www-data -c 'php setup_moodle_webservice.php \
+        --username="$MOODLE_WEB_SERVICE_USER" \
+        --password="$MOODLE_WEB_SERVICE_USER_PASSWORD" \
+        --email="$MOODLE_WEB_SERVICE_USER_EMAIL" \
+        --servicename="$MOODLE_WEB_SERVICE_NAME"'
+fi
+
+if [ $? -eq 0 ]; then
     echo "Now running install process for OIDC plugin..."
     su -s /bin/sh www-data -c '/app/install-oidc-plugin config \
         skip-download \

--- a/apps/moodle-ddev/.ddev/commands/web/install-oidc-plugin
+++ b/apps/moodle-ddev/.ddev/commands/web/install-oidc-plugin
@@ -63,6 +63,9 @@ if [[ "$INSTALL_ACTIONS" == *"config"* ]]; then
     echo "Configuring OIDC settings ..."
     echo "Identity provider type:"
     moosh config-set idptype 3 auth_oidc
+    echo "Client auth method:"
+    # Without this, you get: "Please configure OpenID Connect client credentials and endpoints."
+    moosh config-set clientauthmethod 1 auth_oidc
     echo "Client ID:"
     moosh config-set clientid $AUTH_CLIENT_ID auth_oidc
     echo "Client secret:"

--- a/apps/moodle-docker/config.php
+++ b/apps/moodle-docker/config.php
@@ -44,6 +44,9 @@ $CFG->directorypermissions = 02777;
 if (getenv('MOODLE_SWITCH_OFF_GOVUK_THEMING') !== 'true') {
   $CFG->theme = 'govuk'; 
 }
+if (getenv('MOODLE_SWITCH_OFF_OAUTH') === 'true') {
+  $CFG->auth = 'manual'; 
+}
 
 // The Moodle instances should NOT run their own cron jobs
 $CFG->cronclionly = true;

--- a/apps/user-management/apps/frontend/Configuration/FeatureFlags.cs
+++ b/apps/user-management/apps/frontend/Configuration/FeatureFlags.cs
@@ -1,0 +1,9 @@
+namespace Dfe.Sww.Ecf.Frontend.Configuration;
+
+public class FeatureFlags
+{
+    public bool EnableDeveloperExceptionPage { get; set; }
+    public bool EnableHttpStrictTransportSecurity { get; set; }
+    public bool EnableContentSecurityPolicyWorkaround { get; set; }
+    public bool EnableForwardedHeaders { get; set; }
+}

--- a/apps/user-management/apps/frontend/Dockerfile-azure
+++ b/apps/user-management/apps/frontend/Dockerfile-azure
@@ -7,6 +7,9 @@ ENV VERSION=${FULL_TAG}
 
 WORKDIR /App
 
+COPY entry-point.sh ./entry-point.sh
+RUN chmod +x entry-point.sh
+
 COPY bin/Release/net8.0/publish/ .
 RUN rm appsettings.* \
     && echo "$VERSION" > wwwroot/version.txt
@@ -49,6 +52,7 @@ RUN --mount=type=secret,id=AZURE_KUDU_SSH_PASSWORD \
         
 ENV ASPNETCORE_HTTP_PORTS=80
 
-ENTRYPOINT ["dotnet", "Dfe.Sww.Ecf.Frontend.dll"]
+ENTRYPOINT ["/App/entry-point.sh"]
+CMD ["dotnet","Dfe.Sww.Ecf.Frontend.dll"]
 
 EXPOSE 80

--- a/apps/user-management/apps/frontend/Pages/Debug/DebugBasePageModel.cs
+++ b/apps/user-management/apps/frontend/Pages/Debug/DebugBasePageModel.cs
@@ -10,7 +10,7 @@ public class DebugBasePageModel(IWebHostEnvironment environment, IOptions<OidcCo
 {
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (environment.IsDevelopment() && oidcConfiguration.Value.EnableDevelopmentBackdoor)
+        if (oidcConfiguration.Value.EnableDevelopmentBackdoor)
         {
             return;
         }

--- a/apps/user-management/apps/frontend/Program.cs
+++ b/apps/user-management/apps/frontend/Program.cs
@@ -4,9 +4,28 @@ using Dfe.Sww.Ecf.Frontend.Installers;
 using Dfe.Sww.Ecf.Frontend.Routing;
 using GovUk.Frontend.AspNetCore;
 using Joonasw.AspNetCore.SecurityHeaders;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
 var builder = WebApplication.CreateBuilder(args);
+
+var featureFlags = builder.Configuration
+    .GetRequiredSection("FeatureFlags")
+    .Get<FeatureFlags>()!;
+
+builder.Services.AddSingleton(featureFlags);
+
+// Need forwarded headers if using Azure Front Door. Note, this needs to be done
+// early, before authentication
+if (featureFlags.EnableForwardedHeaders)
+{
+    builder.Services.Configure<ForwardedHeadersOptions>(options =>
+    {
+        options.ForwardedHeaders = ForwardedHeaders.All;
+        options.KnownNetworks.Clear();
+        options.KnownProxies.Clear();
+    });
+}
 
 // Add services to the container.
 builder.Services.AddGovUkFrontend();
@@ -48,13 +67,17 @@ builder.Services.AddEcfAuthentication(
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.
-if (app.Environment.IsDevelopment())
+if (featureFlags.EnableDeveloperExceptionPage)
 {
     app.UseDeveloperExceptionPage();
 }
 else
 {
     app.UseExceptionHandler("/Home/Error");
+}
+
+if (featureFlags.EnableHttpStrictTransportSecurity)
+{
     // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
@@ -71,11 +94,18 @@ app.UseCsp(csp =>
 
     // Ensure ASP.NET Core's auto refresh works
     // See https://github.com/dotnet/aspnetcore/issues/33068
-    if (builder.Environment.IsDevelopment())
+    if (featureFlags.EnableContentSecurityPolicyWorkaround)
     {
         csp.AllowConnections.ToAnywhere();
     }
 });
+
+// Need forwarded headers if using Azure Front Door. Note, this needs to be done
+// early, before authentication
+if (featureFlags.EnableForwardedHeaders)
+{
+    app.UseForwardedHeaders();
+}
 
 app.UseHttpsRedirection();
 app.UseStaticFiles();

--- a/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
+++ b/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
@@ -8,8 +8,7 @@ public abstract class EcfLinkGenerator(
     IOptions<OidcConfiguration> oidcConfiguration
 )
 {
-    private bool IsBackdoorEnabled =>
-        environment.IsDevelopment() && oidcConfiguration.Value.EnableDevelopmentBackdoor;
+    private bool IsBackdoorEnabled => oidcConfiguration.Value.EnableDevelopmentBackdoor;
 
     public string SignIn() =>
         IsBackdoorEnabled

--- a/apps/user-management/apps/frontend/appsettings.Azure.json
+++ b/apps/user-management/apps/frontend/appsettings.Azure.json
@@ -2,10 +2,17 @@
     "Logging": {
         "LogLevel": {
             "Default": "Information",
-            "Microsoft.AspNetCore": "Warning"
+            "Microsoft.AspNetCore": "Warning",
+            "Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersMiddleware": "Debug"
         }
     },
     "AllowedHosts": "*",
+    "FeatureFlags": {
+        "EnableDeveloperExceptionPage": false,
+        "EnableHttpStrictTransportSecurity": true,
+        "EnableContentSecurityPolicyWorkaround": false,
+        "EnableForwardedHeaders": true
+    },
     "Oidc": {
         "AuthorityUrl": "",
         "ClientId": "",

--- a/apps/user-management/apps/frontend/appsettings.Azure.json
+++ b/apps/user-management/apps/frontend/appsettings.Azure.json
@@ -2,8 +2,7 @@
     "Logging": {
         "LogLevel": {
             "Default": "Information",
-            "Microsoft.AspNetCore": "Warning",
-            "Microsoft.AspNetCore.HttpOverrides.ForwardedHeadersMiddleware": "Debug"
+            "Microsoft.AspNetCore": "Warning"
         }
     },
     "AllowedHosts": "*",

--- a/apps/user-management/apps/frontend/appsettings.Development.json
+++ b/apps/user-management/apps/frontend/appsettings.Development.json
@@ -5,6 +5,12 @@
             "Microsoft.AspNetCore": "Warning"
         }
     },
+    "FeatureFlags": {
+        "EnableDeveloperExceptionPage": true,
+        "EnableHttpStrictTransportSecurity": false,
+        "EnableContentSecurityPolicyWorkaround": true,
+        "EnableForwardedHeaders": false
+    },
     "Oidc": {
         "AuthorityUrl": "https://localhost:7236",
         "ClientId": "dfe-sww-ecf-frontend-dev",

--- a/apps/user-management/apps/frontend/entry-point.sh
+++ b/apps/user-management/apps/frontend/entry-point.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# stop on error (-e) and on unset var expansion (-u)
+set -eu
+# enable pipefail *only* if the shell supports it
+( set -o pipefail 2>/dev/null ) && set -o pipefail
+
+# Support SSH for troubleshooting
+echo "Starting SSH..."
+/usr/sbin/sshd
+
+# Exec the main process passed to us (whatever is specified in CMD)
+exec "$@"

--- a/terraform/auth-service.tf
+++ b/terraform/auth-service.tf
@@ -80,8 +80,10 @@ module "auth_service" {
     "OIDC__ENCRYPTIONCERTIFICATENAME"                  = module.encryption_certificate.cert_name
     "OIDC__APPLICATIONS__0__CLIENTID"                  = local.auth_service_client_id
     "OIDC__APPLICATIONS__0__CLIENTSECRET"              = local.auth_service_client_secret
-    "OIDC__APPLICATIONS__0__REDIRECTURIS__0"           = local.moodle_web_app_oidc_url
-    "OIDC__APPLICATIONS__0__POSTLOGOUTREDIRECTURIS__0" = "${local.moodle_web_app_oidc_url}logout.php"
+    "OIDC__APPLICATIONS__0__REDIRECTURIS__0"           = local.moodle_auth_redirect_uri
+    "OIDC__APPLICATIONS__0__POSTLOGOUTREDIRECTURIS__0" = local.moodle_auth_post_logout_redirect_uri
+    "OIDC__APPLICATIONS__0__REDIRECTURIS__1"           = local.user_management_auth_redirect_uri
+    "OIDC__APPLICATIONS__0__POSTLOGOUTREDIRECTURIS__1" = local.user_management_auth_post_logout_redirect_uri
     "ONELOGIN__CLIENTID"                               = var.one_login_client_id
     "ONELOGIN__CERTIFICATENAME"                        = module.one_login_certificate.cert_name
     "ONELOGIN__URL"                                    = var.one_login_oidc_url

--- a/terraform/envs/d01/env.tfvars
+++ b/terraform/envs/d01/env.tfvars
@@ -28,4 +28,5 @@ auth_service_feature_flag_overrides = {
 one_login_client_id = "p4yA1KMFQIoQbqmtntQZPTfdN_I"
 moodle_app_settings = {
   "MOODLE_SWITCH_OFF_GOVUK_THEMING" = "false"
+  "MOODLE_SWITCH_OFF_OAUTH"         = "false"
 }

--- a/terraform/envs/d02/env.tfvars
+++ b/terraform/envs/d02/env.tfvars
@@ -30,4 +30,5 @@ auth_service_feature_flag_overrides = {
 one_login_client_id = ""
 moodle_app_settings = {
   "MOODLE_SWITCH_OFF_GOVUK_THEMING" = "true"
+  "MOODLE_SWITCH_OFF_OAUTH"         = "true"
 }

--- a/terraform/moodle-web-apps.tf
+++ b/terraform/moodle-web-apps.tf
@@ -27,7 +27,8 @@ locals {
     "MOODLE_ADMIN_EMAIL"                  = var.moodle_admin_email
     DOCKER_ENABLE_CI                      = "false" # Github will control CI, not Azure
   }
-  moodle_web_app_oidc_url = "${module.web_app_moodle["primary"].front_door_app_url}/auth/oidc/"
+  moodle_auth_redirect_uri             = "${module.web_app_moodle["primary"].front_door_app_url}/auth/oidc/"
+  moodle_auth_post_logout_redirect_uri = "${local.moodle_auth_redirect_uri}logout.php"
 }
 
 resource "random_password" "web_service_user_password" {

--- a/terraform/user-management.tf
+++ b/terraform/user-management.tf
@@ -1,3 +1,8 @@
+locals {
+  user_management_auth_redirect_uri             = "${module.user_management.front_door_app_url}/oidc/callback"
+  user_management_auth_post_logout_redirect_uri = "${module.user_management.front_door_app_url}/oidc/logout-callback"
+}
+
 module "user_management" {
   source                    = "./modules/web-app"
   tenant_id                 = data.azurerm_client_config.az_config.tenant_id
@@ -18,7 +23,7 @@ module "user_management" {
 
   # The settings name syntax below (e.g. OIDC__AUTHORITYURL) is how .NET imports environment 
   # variables to override the properties in its multi-level appsettings.json file
-  # 
+  #
   app_settings = {
     "ENVIRONMENT"                             = var.environment
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE"     = "false"


### PR DESCRIPTION
- Enabled web service during deployment
- Enabled Kudu / SSH for user management / auth service
- Provides Moodle app setting MOODLE_SWITCH_OFF_OAUTH to allow OAuth to be toggled on and off for an environment
- Refactored IsDevelopment() checks to feature flags for user management
- Add user management redirects for auth service