### PR TITLE
SWIP-521 Basic auth for Moodle site

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -134,6 +134,8 @@ jobs:
             -var='moodle_web_service_name=${{ vars.MOODLE_WEB_SERVICE_NAME }}' \
             -var='moodle_web_service_user=${{ vars.MOODLE_WEB_SERVICE_USER }}' \
             -var='moodle_web_service_user_email=${{ vars.MOODLE_WEB_SERVICE_USER_EMAIL }}' \
+            -var='basic_auth_user=${{ vars.BASIC_AUTH_USER }}' \
+            -var='basic_auth_password=${{ secrets.BASIC_AUTH_PASSWORD }}' \
             || export exitcode=$?
 
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT

--- a/apps/moodle-apps-azure/Dockerfile
+++ b/apps/moodle-apps-azure/Dockerfile
@@ -105,12 +105,13 @@ ARG PHP_COMPOSER_VERSION=2.6.5
 
 WORKDIR /var/www/html/public
 
-# Mandatory tools for remote SSH
+# Mandatory tools for remote SSH + general mgmt
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         openssh-server \
         postgresql-client \
         cron \
+        apache2-utils \
     && rm -rf /var/lib/apt/lists/*
 
 # Support kudu tools SSH for remote debug
@@ -144,7 +145,7 @@ USER root
 RUN curl -sS https://getcomposer.org/installer -o composer-setup.php \
     && php composer-setup.php --version=${PHP_COMPOSER_VERSION} --install-dir=/usr/local/bin --filename=composer \
     && rm composer-setup.php \
-    && composer --version    
+    && composer --version
 
 # Moosh is required to run the install-oidc-plugin script at deployment time
 COPY install-moosh install-moosh
@@ -158,6 +159,7 @@ COPY entry-point.sh /app/entry-point.sh
 COPY maintain-moodle.sh /app/maintain-moodle.sh
 COPY save-env.sh /app/save-env.sh
 COPY restore-env.sh /app/restore-env.sh
+COPY apache-config-moodle-basic-auth.conf /app/apache-config-moodle-basic-auth.conf
 RUN chmod +x /app/entry-point.sh /app/maintain-moodle.sh /app/save-env.sh /app/restore-env.sh
 
 # Default config is full-blown moodle instance - if not the case, the entry point script

--- a/apps/moodle-apps-azure/apache-config-moodle-basic-auth.conf
+++ b/apps/moodle-apps-azure/apache-config-moodle-basic-auth.conf
@@ -1,0 +1,48 @@
+<VirtualHost *:80>
+        # The ServerName directive sets the request scheme, hostname and port that
+        # the server uses to identify itself. This is used when creating
+        # redirection URLs. In the context of virtual hosts, the ServerName
+        # specifies what hostname must appear in the request's Host: header to
+        # match this virtual host. For the default virtual host (this file) this
+        # value is not decisive as it is used as a last resort host regardless.
+        # However, you must set it for any further virtual host explicitly.
+        #ServerName www.example.com
+
+        ServerAdmin webmaster@localhost
+        DocumentRoot /var/www/html/public
+        DirectoryIndex index.php
+
+        # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
+        # error, crit, alert, emerg.
+        # It is also possible to configure the loglevel for particular
+        # modules, e.g.
+        #LogLevel info ssl:warn
+
+        ErrorLog ${APACHE_LOG_DIR}/error.log
+        CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        # Exempt /version.txt from basic auth
+        <Location "/version.txt">
+                Require all granted
+        </Location>
+
+        # Exempt the REST endpoint from basic auth
+        <Location "/webservice/rest/server.php">
+                Require all granted
+        </Location>
+
+        # Protect everything else with basic auth
+        <LocationMatch "^/(?!version\.txt$|webservice/rest/server\.php$)">
+                AuthType Basic
+                AuthName "Restricted Area"
+                AuthUserFile /etc/apache2/.htpasswd
+                Require valid-user
+        </LocationMatch>
+
+        # For most configuration files from conf-available/, which are
+        # enabled or disabled at a global level, it is possible to
+        # include a line for only one particular virtual host. For example the
+        # following line enables the CGI configuration for this host only
+        # after it has been globally disabled with "a2disconf".
+        #Include conf-available/serve-cgi-bin.conf
+</VirtualHost>

--- a/apps/moodle-apps-azure/entry-point.sh
+++ b/apps/moodle-apps-azure/entry-point.sh
@@ -19,8 +19,13 @@ if [[ "$IS_CRON_JOB_ONLY" == 'true' ]]; then
     mv /var/www/html/public/version.txt /var/www/html/cron/version.txt
     echo "Starting cron daemon..."
     /usr/sbin/cron
-else
+else 
     echo "This will be a full Moodle instance..."
+    if [[ "$BASIC_AUTH_ENABLED" == 'true' ]]; then
+        # Configure basic auth to restrict access / prevent Moodle from being indexed
+        htpasswd -b -c /etc/apache2/.htpasswd "$BASIC_AUTH_USER" "$BASIC_AUTH_PASSWORD"
+        cp /app/apache-config-moodle-basic-auth.conf /etc/apache2/sites-available/000-default.conf
+    fi
 fi
 
 cd /var/www/html/public

--- a/terraform/envs/d01/env.tfvars
+++ b/terraform/envs/d01/env.tfvars
@@ -29,4 +29,5 @@ one_login_client_id = "p4yA1KMFQIoQbqmtntQZPTfdN_I"
 moodle_app_settings = {
   "MOODLE_SWITCH_OFF_GOVUK_THEMING" = "false"
   "MOODLE_SWITCH_OFF_OAUTH"         = "false"
+  "BASIC_AUTH_ENABLED"              = "true"
 }

--- a/terraform/envs/d02/env.tfvars
+++ b/terraform/envs/d02/env.tfvars
@@ -31,4 +31,5 @@ one_login_client_id = ""
 moodle_app_settings = {
   "MOODLE_SWITCH_OFF_GOVUK_THEMING" = "true"
   "MOODLE_SWITCH_OFF_OAUTH"         = "true"
+  "BASIC_AUTH_ENABLED"              = "true"
 }

--- a/terraform/modules/environment-stack/app-services.tf
+++ b/terraform/modules/environment-stack/app-services.tf
@@ -1,3 +1,21 @@
+resource "azurerm_key_vault_secret" "basic_auth_password" {
+  name            = "Sites-BasicAuthPassword"
+  value           = var.basic_auth_password
+  key_vault_id    = azurerm_key_vault.kv.id
+  content_type    = "password"
+
+  // TODO: Managed expiry of db passwords
+  //expiration_date = local.expiration_date
+
+  lifecycle {
+    ignore_changes = [expiration_date]
+  }
+
+  depends_on = [ azurerm_key_vault_access_policy.kv_gh_ap ]
+
+  #checkov:skip=CKV_AZURE_41:Ensure that the expiration date is set on all secrets
+}
+
 ################################################
 # App Service Plan for Moodle application
 ################################################

--- a/terraform/modules/environment-stack/variables.tf
+++ b/terraform/modules/environment-stack/variables.tf
@@ -84,3 +84,9 @@ variable "assign_delivery_team_key_vault_permissions" {
   description = "Whether to assign the delivery team key vault permissions as a convenience"
   type        = bool
 }
+
+variable "basic_auth_password" {
+  description = "Password for basic auth protected sites"
+  type        = string
+  sensitive   = true
+}

--- a/terraform/moodle-web-apps.tf
+++ b/terraform/moodle-web-apps.tf
@@ -92,6 +92,8 @@ module "web_app_moodle" {
     "AUTH_SERVICE_END_POINT"           = local.auth_service_end_point
     "AUTH_SERVICE_TOKEN_END_POINT"     = local.auth_service_token_end_point
     "AUTH_SERVICE_LOGOUT_URI"          = local.auth_service_logout_uri
+    "BASIC_AUTH_USER"                  = var.basic_auth_user
+    "BASIC_AUTH_PASSWORD"              = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/Sites-BasicAuthPassword)"
   }, var.moodle_app_settings, local.moodle_shared_app_settings)
 
   depends_on = [

--- a/terraform/stack.tf
+++ b/terraform/stack.tf
@@ -10,5 +10,6 @@ module "stack" {
   admin_enabled                              = var.admin_enabled
   webapp_storage_account_name                = var.webapp_storage_account_name
   assign_delivery_team_key_vault_permissions = var.assign_delivery_team_key_vault_permissions
+  basic_auth_password                        = var.basic_auth_password
   tags                                       = local.common_tags
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -119,6 +119,7 @@ variable "moodle_site_shortname" {
 variable "moodle_admin_user" {
   description = "The username for the admin account on Moodle"
   type        = string
+  sensitive   = true
 }
 
 variable "moodle_admin_password" {
@@ -130,6 +131,7 @@ variable "moodle_admin_password" {
 variable "moodle_admin_email" {
   description = "The email address to use for the admin user on Moodle"
   type        = string
+  sensitive   = true
 }
 
 variable "moodle_db_type" {
@@ -156,11 +158,13 @@ variable "assign_delivery_team_key_vault_permissions" {
 variable "auth_service_client_id" {
   description = "Client ID for authentication into auth service"
   type        = string
+  sensitive   = true
 }
 
 variable "auth_service_client_secret" {
   description = "Client secret for authentication into auth services"
   type        = string
+  sensitive   = true
 }
 
 variable "one_login_oidc_url" {
@@ -172,6 +176,7 @@ variable "one_login_oidc_url" {
 variable "one_login_client_id" {
   description = "The client ID for one login (non-secret)"
   type        = string
+  sensitive   = true
 }
 
 variable "auth_service_feature_flag_overrides" {
@@ -193,9 +198,23 @@ variable "moodle_web_service_name" {
 variable "moodle_web_service_user" {
   description = "Name of Moodle web service user"
   type        = string
+  sensitive   = true
 }
 
 variable "moodle_web_service_user_email" {
   description = "Email of Moodle web service user"
   type        = string
+  sensitive   = true
+}
+
+variable "basic_auth_user" {
+  description = "User ID for basic auth protected sites"
+  type        = string
+  sensitive   = true
+}
+
+variable "basic_auth_password" {
+  description = "Password for basic auth protected sites"
+  type        = string
+  sensitive   = true
 }


### PR DESCRIPTION
Basic auth for Moodle only. Relies on 3 app settings controlled from Terraform:
- BASIC_AUTH_ENABLED
- BASIC_AUTH_USER
- BASIC_AUTH_USER
Endpoints /version.txt (version confirmation) plus /webservice/rest/server.php (web service endpoint) remain unprotected.
One user / password for all environments and sites for ease of use.
User management next. 