### PR TITLE
SWIP-521 Basic auth for web sites - user management

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -130,7 +130,6 @@ jobs:
             -var='moodle_admin_email=${{ vars.MOODLE_ADMIN_EMAIL }}' \
             -var='moodle_admin_user=${{ vars.MOODLE_ADMIN_USER }}' \
             -var='auth_service_client_id=${{ vars.AUTH_SERVICE_CLIENT_ID }}' \
-            -var='auth_service_client_secret=${{ secrets.AUTH_SERVICE_CLIENT_SECRET }}' \
             -var='moodle_web_service_name=${{ vars.MOODLE_WEB_SERVICE_NAME }}' \
             -var='moodle_web_service_user=${{ vars.MOODLE_WEB_SERVICE_USER }}' \
             -var='moodle_web_service_user_email=${{ vars.MOODLE_WEB_SERVICE_USER_EMAIL }}' \

--- a/apps/moodle-apps-azure/entry-point.sh
+++ b/apps/moodle-apps-azure/entry-point.sh
@@ -23,7 +23,8 @@ else
     echo "This will be a full Moodle instance..."
     if [[ "$BASIC_AUTH_ENABLED" == 'true' ]]; then
         # Configure basic auth to restrict access / prevent Moodle from being indexed
-        htpasswd -b -c /etc/apache2/.htpasswd "$BASIC_AUTH_USER" "$BASIC_AUTH_PASSWORD"
+        echo "Configuring basic auth..."
+        htpasswd -b -c /etc/apache2/.htpasswd "$BASIC_AUTH_USER" "$BASIC_AUTH_PASSWORD" > /dev/null
         cp /app/apache-config-moodle-basic-auth.conf /etc/apache2/sites-available/000-default.conf
     fi
 fi

--- a/apps/moodle-apps-azure/justfile
+++ b/apps/moodle-apps-azure/justfile
@@ -96,33 +96,16 @@ database-updates resource-group web-app-name full-image-tag:
     --query value -o tsv 2>&1) \
     && { 
       MOODLE_WEB_SERVICE_TOKEN="$AZ_OUTPUT"
+      # Make sure we don't echo the token to the logs
+      echo "::add-mask::$MOODLE_WEB_SERVICE_TOKEN"
       echo "Retrieved Moodle web service token from key vault: $KEY_VAULT_NAME, $SECRET_NAME" >&2
     } || {
       AZ_RC=$?
 
-      if echo "$AZ_OUTPUT" | grep -qiE 'SecretNotFound|404'; then
-        MOODLE_WEB_SERVICE_TOKEN=$(printf '%s' "$(date +%s%N)$RANDOM" \
-          | md5sum \
-          | cut -d' ' -f1)
-
-        echo "Saving generated Moodle web service token in key vault: $KEY_VAULT_NAME, $SECRET_NAME" >&2
-        az keyvault secret set \
-          --vault-name       $KEY_VAULT_NAME \
-          --name             $SECRET_NAME \
-          --content-type     "client secret" \
-          --value            "$MOODLE_WEB_SERVICE_TOKEN" \
-          -o                 none \
-          --only-show-errors
-
-      else
-        # Otherwise re-emit the error and exit
-        echo "❌ Failed fetching secret: $AZ_OUTPUT" >&2
-        exit $AZ_RC
-      fi
+      echo "❌ Failed fetching secret: $AZ_OUTPUT" >&2
+      exit $AZ_RC
     }
-  # Make sure we don't echo the token to the logs
-  echo "::add-mask::$MOODLE_WEB_SERVICE_TOKEN"
-
+    
   ##############################################################
   # Step 2: Establish background SSH connection to app service #
   # Do this as close as possible to the ssh session below.     #

--- a/apps/user-management/apps/frontend/Dockerfile-azure
+++ b/apps/user-management/apps/frontend/Dockerfile-azure
@@ -31,7 +31,8 @@ COPY appsettings.Azure.json appsettings.json
 RUN apk add --no-cache \
     tzdata \
     icu-data-full \
-    icu-libs
+    icu-libs \
+    curl
 
 # Flips .NET back on to use ICU rather than the invariant fallback
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
@@ -49,10 +50,21 @@ RUN --mount=type=secret,id=AZURE_KUDU_SSH_PASSWORD \
     && mkdir -p /var/run/sshd \
     && chmod 0755 /var/run/sshd \
     && ssh-keygen -A
-        
-ENV ASPNETCORE_HTTP_PORTS=80
+
+# Serve on port 5000 behind lighttpd
+ENV ASPNETCORE_HTTP_PORTS=5000
+ENV ASPNETCORE_URLS=http://+:5000
+
+# Install Lighttpd, proxy+auth modules and htpasswd tool for basic auth
+RUN apk update && \
+    apk add --no-cache \
+    nginx \
+    apache2-utils
+
+COPY nginx.conf /etc/nginx/http.d/default.conf
+COPY nginx-basic-auth.conf /App/nginx-basic-auth.conf
 
 ENTRYPOINT ["/App/entry-point.sh"]
-CMD ["dotnet","Dfe.Sww.Ecf.Frontend.dll"]
+CMD ["nginx","-g", "daemon off;"]
 
 EXPOSE 80

--- a/apps/user-management/apps/frontend/entry-point.sh
+++ b/apps/user-management/apps/frontend/entry-point.sh
@@ -8,5 +8,53 @@ set -eu
 echo "Starting SSH..."
 /usr/sbin/sshd
 
-# Exec the main process passed to us (whatever is specified in CMD)
+if [ "$BASIC_AUTH_ENABLED" = 'true' ]; then
+    # Configure basic auth to restrict access / prevent user management from being indexed
+    echo "Configuring basic auth..."
+    htpasswd -b -c /etc/nginx/.htpasswd "$BASIC_AUTH_USER" "$BASIC_AUTH_PASSWORD" > /dev/null 2>&1
+    cp /App/nginx-basic-auth.conf /etc/nginx/http.d/default.conf
+fi
+
+# Launch user management
+dotnet Dfe.Sww.Ecf.Frontend.dll &
+
+echo "Waiting for user management to be ready..."
+ENDPOINT=http://localhost:5000/version.txt
+EXPECTED_RESPONSE=$(cat /App/wwwroot/version.txt)
+TOTAL_TIMEOUT=10
+TIMEOUT_PER_REQUEST=2 # seconds
+SLEEP_INTERVAL=1      # seconds between retries
+
+start_time=$(date +%s)
+RESPONSE=""
+
+while true; do
+    NOW=$(date +%s)
+    ELAPSED=$(( NOW - start_time ))
+
+    if [ "$ELAPSED" -ge "$TOTAL_TIMEOUT" ]; then
+        echo "❌ Timed out after ${TOTAL_TIMEOUT}s waiting for $ENDPOINT" >&2
+        exit 1
+    fi
+
+    # Run the request, but don’t abort the script on timeout/failure
+    if BODY=$(curl --silent --show-error --max-time $TIMEOUT_PER_REQUEST "$ENDPOINT"); then
+        if [ -n "$BODY" ]; then
+            if [ "$BODY" == "$EXPECTED_RESPONSE" ]; then
+                RESPONSE="$BODY"
+                echo "✅ Got correct endpoint response '$EXPECTED_RESPONSE' after ${ELAPSED}s:"
+                echo "$RESPONSE"
+                break
+            else
+                echo "⏳ Got incorrect endpoint response '$BODY', expected '$EXPECTED_RESPONSE' after ${ELAPSED}s:"
+            fi
+        fi
+    else
+        echo "⏳ Attempt at ${ELAPSED}s failed or timed out (allowed ${TIMEOUT_PER_REQUEST}s)."
+    fi
+
+    sleep $SLEEP_INTERVAL
+done
+
+# Exec the main process passed to us (whatever is specified in CMD - usually lighttpd)
 exec "$@"

--- a/apps/user-management/apps/frontend/nginx-basic-auth.conf
+++ b/apps/user-management/apps/frontend/nginx-basic-auth.conf
@@ -1,0 +1,43 @@
+map $http_x_forwarded_host $final_kestrel_host {
+    default $http_x_forwarded_host; # Use X-Forwarded-Host from Front Door if present
+    ""      $host;                  # Otherwise, fallback to the Host header Nginx received
+}
+
+upstream kestrel {
+    server 127.0.0.1:5000;
+}
+
+server {
+    listen 80;
+
+    access_log /proc/self/fd/1 combined;
+    error_log /proc/self/fd/2 warn;
+
+    auth_basic_user_file /etc/nginx/.htpasswd;
+
+    # === Public health-check (no authentication) ===
+    location = /version.txt {
+        auth_basic off;
+
+        # Forward relevant headers to Kestrel.
+        proxy_set_header Host              $final_kestrel_host;
+        proxy_set_header X-Forwarded-Host  $final_kestrel_host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+        proxy_pass http://kestrel;
+    }
+
+    # === Protect everything else with basic authentication ===
+    location / {
+        auth_basic "Restricted Area";
+
+        # Forward relevant headers to Kestrel
+        proxy_set_header Host              $final_kestrel_host;
+        proxy_set_header X-Forwarded-Host  $final_kestrel_host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+        proxy_pass http://kestrel;
+    }
+}

--- a/apps/user-management/apps/frontend/nginx.conf
+++ b/apps/user-management/apps/frontend/nginx.conf
@@ -1,0 +1,25 @@
+map $http_x_forwarded_host $final_kestrel_host {
+    default $http_x_forwarded_host; # Use X-Forwarded-Host from Front Door if present
+    ""      $host;                  # Otherwise, fallback to the Host header Nginx received
+}
+
+upstream kestrel {
+    server 127.0.0.1:5000;
+}
+
+server {
+    listen 80;
+
+    access_log /proc/self/fd/1 main;
+    error_log /proc/self/fd/2 info;
+
+    location / {
+        # Forward relevant headers to Kestrel
+        proxy_set_header Host              $final_kestrel_host;
+        proxy_set_header X-Forwarded-Host  $final_kestrel_host;
+        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+
+        proxy_pass http://kestrel;
+    }
+}

--- a/apps/user-management/apps/frontend/sshd_config
+++ b/apps/user-management/apps/frontend/sshd_config
@@ -10,4 +10,3 @@ PasswordAuthentication 	yes
 PermitEmptyPasswords 	no
 PermitRootLogin 	yes
 Subsystem sftp internal-sftp
-UsePAM no

--- a/scripts/setup_moodle_webservice.php
+++ b/scripts/setup_moodle_webservice.php
@@ -181,7 +181,14 @@ if (!$token) {
     $DB->insert_record('external_tokens', $token);
     echo "Created token: {$token->token}\n";
 } else {
-    echo "Token already exists: {$token->token}\n";
+    if ($tokenParam && $tokenParam !== $token->token) {
+        $token->token = $tokenParam;
+        $token->timecreated = time();
+        $DB->update_record('external_tokens', $token);
+        echo "Updated token to: {$token->token}\n";
+    } else {
+        echo "Token already exists: {$token->token}\n";
+    }
 }
 
 // List of Moodle web service functions you want to allow

--- a/terraform/envs/d01/env.tfvars
+++ b/terraform/envs/d01/env.tfvars
@@ -21,7 +21,7 @@ moodle_instances = {
   primary = {}
 }
 # Enable dev friendly auth services features in dev environment
-auth_service_feature_flag_overrides = {
+auth_service_app_settings = {
   "FEATUREFLAGS__ENABLEDEVELOPEREXCEPTIONPAGE" = "true"
   "FEATUREFLAGS__ENABLESWAGGER"                = "true"
 }
@@ -30,4 +30,7 @@ moodle_app_settings = {
   "MOODLE_SWITCH_OFF_GOVUK_THEMING" = "false"
   "MOODLE_SWITCH_OFF_OAUTH"         = "false"
   "BASIC_AUTH_ENABLED"              = "true"
+}
+user_management_app_settings = {
+  "BASIC_AUTH_ENABLED" = "true"
 }

--- a/terraform/envs/d02/env.tfvars
+++ b/terraform/envs/d02/env.tfvars
@@ -22,7 +22,7 @@ moodle_instances = {
   primary = {}
 }
 # Enable dev friendly auth services features in dev environment
-auth_service_feature_flag_overrides = {
+auth_service_app_settings = {
   "FEATUREFLAGS__ENABLEDEVELOPEREXCEPTIONPAGE" = "true"
   "FEATUREFLAGS__ENABLESWAGGER"                = "true"
 }
@@ -32,4 +32,8 @@ moodle_app_settings = {
   "MOODLE_SWITCH_OFF_GOVUK_THEMING" = "true"
   "MOODLE_SWITCH_OFF_OAUTH"         = "true"
   "BASIC_AUTH_ENABLED"              = "true"
+}
+
+user_management_app_settings = {
+  "BASIC_AUTH_ENABLED" = "true"
 }

--- a/terraform/moodle-web-apps.tf
+++ b/terraform/moodle-web-apps.tf
@@ -55,6 +55,28 @@ resource "azurerm_key_vault_secret" "web_service_user_password" {
   #checkov:skip=CKV_AZURE_41:Ensure that the expiration date is set on all secrets
 }
 
+resource "random_id" "web_service_token" {
+  byte_length = 16
+}
+
+resource "azurerm_key_vault_secret" "web_service_token" {
+  name         = "Moodle-WebServiceToken"
+  value        = random_id.web_service_token.hex
+  key_vault_id = module.stack.kv_id
+  content_type = "access token"
+
+  // TODO: Managed expiry of passwords
+  //expiration_date = local.expiration_date
+
+  lifecycle {
+    ignore_changes = [value, expiration_date]
+  }
+
+  depends_on = [module.stack]
+
+  #checkov:skip=CKV_AZURE_41:Ensure that the expiration date is set on all secrets
+}
+
 resource "azurerm_postgresql_flexible_server_database" "moodle_db" {
   for_each  = local.moodle_instance_resource_naming
   server_id = module.stack.db_server_id

--- a/terraform/user-management.tf
+++ b/terraform/user-management.tf
@@ -24,7 +24,7 @@ module "user_management" {
   # The settings name syntax below (e.g. OIDC__AUTHORITYURL) is how .NET imports environment 
   # variables to override the properties in its multi-level appsettings.json file
   #
-  app_settings = {
+  app_settings = merge({
     "ENVIRONMENT"                             = var.environment
     "WEBSITES_ENABLE_APP_SERVICE_STORAGE"     = "false"
     "OIDC__AUTHORITYURL"                      = module.auth_service.front_door_app_url
@@ -33,6 +33,8 @@ module "user_management" {
     "SOCIALWORKENGLANDCLIENTOPTIONS__BASEURL" = "TBD" # TODO: SWE API usage deprioritised
     "AUTHCLIENTOPTIONS__BASEURL"              = module.auth_service.front_door_app_url
     "MOODLECLIENTOPTIONS__BASEURL"            = "${module.web_app_moodle["primary"].front_door_app_url}/webservice/rest/server.php"
+    "BASIC_AUTH_USER"                         = var.basic_auth_user
+    "BASIC_AUTH_PASSWORD"                     = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/Sites-BasicAuthPassword)"
     DOCKER_ENABLE_CI                          = "false" # Github will control CI, not Azure
-  }
+  }, var.user_management_app_settings)
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -161,12 +161,6 @@ variable "auth_service_client_id" {
   sensitive   = true
 }
 
-variable "auth_service_client_secret" {
-  description = "Client secret for authentication into auth services"
-  type        = string
-  sensitive   = true
-}
-
 variable "one_login_oidc_url" {
   description = "One Login URL for OIDC integration"
   type        = string
@@ -179,13 +173,19 @@ variable "one_login_client_id" {
   sensitive   = true
 }
 
-variable "auth_service_feature_flag_overrides" {
+variable "auth_service_app_settings" {
   description = "Environment specific auth service feature flag overrides"
   type        = map(string)
 }
 
 variable "moodle_app_settings" {
   description = "Environment specific Moodle app settings"
+  type        = map(string)
+  default     = {}
+}
+
+variable "user_management_app_settings" {
+  description = "Environment specific user management app settings"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
- Added basic auth to user management (main Moodle site already done) - uses Nginx as couldn't get lighttpd to respect the incoming forwarded headers from front-door
- Toggle basic auth with app setting BASIC_AUTH_ENABLED ('true' / 'false'), uses values: BASIC_AUTH_USER (Github repo variable) and BASIC_AUTH_PASSWORD (Github repo secret - though stored by Terraform in key vault)
- Refactored Moodle web service token to be generated in Terraform
- Refactored auth service client secret generation in Terraform rather than storing in Github secret
- Refactored auth_service_feature_flag_overrides - renamed to auth_service_app_settings in line with other services
- Refactored web service token handling to support replacement if different to current value
