### PR TITLE
Swip-776 Separate basic auth password for end user environments

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -135,7 +135,8 @@ jobs:
             -var='moodle_web_service_user=${{ vars.MOODLE_WEB_SERVICE_USER }}' \
             -var='moodle_web_service_user_email=${{ vars.MOODLE_WEB_SERVICE_USER_EMAIL }}' \
             -var='basic_auth_user=${{ vars.BASIC_AUTH_USER }}' \
-            -var='basic_auth_password=${{ secrets.BASIC_AUTH_PASSWORD }}' \
+            -var='basic_auth_password_team_environments=${{ secrets.BASIC_AUTH_PASSWORD_TEAM_ENVIRONMENTS }}' \
+            -var='basic_auth_password_user_environments=${{ secrets.BASIC_AUTH_PASSWORD_USER_ENVIRONMENTS }}' \
             -var='email_support_address=${{ vars.EMAIL_SUPPORT_ADDRESS }}' \
             || export exitcode=$?
 

--- a/terraform/envs/d01/env.tfvars
+++ b/terraform/envs/d01/env.tfvars
@@ -6,6 +6,7 @@ azure_region = "westeurope"
 environment = "development"
 resource_name_prefix = "${project_code}d01"
 primary_resource_group = "${project_code}d01-swip-rg"
+environment_audience = "team"
 create_and_own_container_registry = true
 acr_name = "${project_code}d01acr"
 acr_sku = "Basic"

--- a/terraform/envs/d02/env.tfvars
+++ b/terraform/envs/d02/env.tfvars
@@ -6,6 +6,7 @@ azure_region = "westeurope"
 environment = "development"
 resource_name_prefix = "${project_code}d02"
 primary_resource_group = "${project_code}d02-swip-rg"
+environment_audience = "team"
 acr_name = "${project_code}d01acr"
 # The container registry is shared from the d01 instance
 acr_resource_group = "${project_code}d01-swip-rg"

--- a/terraform/envs/d03/env.tfvars
+++ b/terraform/envs/d03/env.tfvars
@@ -6,6 +6,7 @@ azure_region = "westeurope"
 environment = "development"
 resource_name_prefix = "${project_code}d03"
 primary_resource_group = "${project_code}d03-swip-rg"
+environment_audience = "user"
 acr_name = "${project_code}d01acr"
 # The container registry is shared from the d01 instance
 acr_resource_group = "${project_code}d01-swip-rg"

--- a/terraform/local.tf
+++ b/terraform/local.tf
@@ -6,4 +6,5 @@ locals {
     "Product"          = var.product_tag
     "Service Offering" = var.service_offering_tag
   }
+  basic_auth_password = var.environment_audience == "team" ? var.basic_auth_password_team_environments : var.basic_auth_password_user_environments
 }

--- a/terraform/stack.tf
+++ b/terraform/stack.tf
@@ -10,7 +10,7 @@ module "stack" {
   admin_enabled                              = var.admin_enabled
   webapp_storage_account_name                = var.webapp_storage_account_name
   assign_delivery_team_key_vault_permissions = var.assign_delivery_team_key_vault_permissions
-  basic_auth_password                        = var.basic_auth_password
+  basic_auth_password                        = local.basic_auth_password
   email_support_address                      = var.email_support_address
   tags                                       = local.common_tags
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -213,8 +213,14 @@ variable "basic_auth_user" {
   sensitive   = true
 }
 
-variable "basic_auth_password" {
-  description = "Password for basic auth protected sites"
+variable "basic_auth_password_team_environments" {
+  description = "Password for basic auth protected sites in project team environments"
+  type        = string
+  sensitive   = true
+}
+
+variable "basic_auth_password_user_environments" {
+  description = "Password for basic auth protected sites in end user environments"
   type        = string
   sensitive   = true
 }
@@ -223,4 +229,18 @@ variable "email_support_address" {
   description = "Email address for support / alerting"
   type        = string
   sensitive   = true
+}
+
+variable "environment_audience" {
+  type        = string
+  description = "The type of environment. Must be one of: team, user."
+
+  validation {
+    condition = contains(
+      ["team", "user"],
+      var.environment_audience
+    )
+
+    error_message = "The specified environment_audience is not valid. Allowed values are: team, user."
+  }
 }


### PR DESCRIPTION
Now uses either the Github repo secret BASIC_AUTH_PASSWORD_TEAM_ENVIRONMENTS or BASIC_AUTH_PASSWORD_USER_ENVIRONMENTS for basic auth password depending on whether the Terraform variable environment_type is set to 'team' or 'user'.