### PR TITLE
SWIP-650 - View user details status label

### DIFF
--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Models/PersonStatus.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Models/PersonStatus.cs
@@ -4,6 +4,5 @@ public enum PersonStatus
 {
     Active,
     Inactive,
-    PendingRegistration,
-    Paused,
+    PendingRegistration
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/TagHelpers/AccountStatusTagHelperTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/TagHelpers/AccountStatusTagHelperTests.cs
@@ -1,0 +1,75 @@
+using System.Text.Encodings.Web;
+using Dfe.Sww.Ecf.Frontend.Models;
+using Dfe.Sww.Ecf.Frontend.TagHelpers;
+using Dfe.Sww.Ecf.Frontend.Test.UnitTests.Helpers;
+using FluentAssertions;
+using GovUk.Frontend.AspNetCore;
+using Xunit;
+
+namespace Dfe.Sww.Ecf.Frontend.Test.UnitTests.TagHelpers;
+
+public class AccountStatusTagHelperTests
+{
+    [Fact]
+    public async Task ProcessAsync_WithActiveStatus_GeneratesExpectedOutput()
+    {
+        // Arrange
+        var (context, output) = TagHelperHelpers.CreateContextAndOutput("account-status");
+        var sut = new AccountStatusTagHelper { Status = AccountStatus.Active };
+
+        // Act
+        await sut.ProcessAsync(context, output);
+
+        // Assert
+        const string expectedHtml =
+            "<strong class=\"govuk-tag govuk-tag--green\" data-test-class=\"account-status\">Active</strong>";
+        output.ToHtmlString(HtmlEncoder.Default).Should().Be(expectedHtml);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithPendingStatus_GeneratesExpectedOutput()
+    {
+        // Arrange
+        var (context, output) = TagHelperHelpers.CreateContextAndOutput("account-status");
+        var sut = new AccountStatusTagHelper { Status = AccountStatus.PendingRegistration };
+
+        // Act
+        await sut.ProcessAsync(context, output);
+
+        // Assert
+        const string expectedHtml =
+            "<strong class=\"govuk-tag govuk-tag--grey\" data-test-class=\"account-status\">Pending</strong>";
+        output.ToHtmlString(HtmlEncoder.Default).Should().Be(expectedHtml);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithInactiveStatus_GeneratesExpectedOutput()
+    {
+        // Arrange
+        var (context, output) = TagHelperHelpers.CreateContextAndOutput("account-status");
+        var sut = new AccountStatusTagHelper { Status = AccountStatus.Inactive };
+
+        // Act
+        await sut.ProcessAsync(context, output);
+
+        // Assert
+        const string expectedHtml =
+            "<strong class=\"govuk-tag govuk-tag--yellow\" data-test-class=\"account-status\">Inactive</strong>";
+        output.ToHtmlString(HtmlEncoder.Default).Should().Be(expectedHtml);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithBlankStatus_GeneratesExpectedOutput()
+    {
+        // Arrange
+        var (context, output) = TagHelperHelpers.CreateContextAndOutput("account-status");
+        var sut = new AccountStatusTagHelper { Status = null };
+
+        // Act
+        await sut.ProcessAsync(context, output);
+
+        // Assert
+        const string expectedHtml = "";
+        output.ToHtmlString(HtmlEncoder.Default).Should().Be(expectedHtml);
+    }
+}

--- a/apps/user-management/apps/frontend/Models/AccountStatus.cs
+++ b/apps/user-management/apps/frontend/Models/AccountStatus.cs
@@ -3,13 +3,13 @@ using System.ComponentModel.DataAnnotations;
 namespace Dfe.Sww.Ecf.Frontend.Models;
 
 /// <summary>
-/// Account Status
+///     Account Status
 /// </summary>
 public enum AccountStatus
 {
-    [Display(Name = "Active")]
-    Active,
+    [Display(Name = "Active")] Active,
 
-    [Display(Name = "Pending")]
-    PendingRegistration
+    [Display(Name = "Inactive")] Inactive,
+
+    [Display(Name = "Pending")] PendingRegistration
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/Index.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/Index.cshtml
@@ -1,10 +1,5 @@
 @page
-@using Dfe.Sww.Ecf.Frontend.Extensions
-@using Dfe.Sww.Ecf.Frontend.Models
-@using Dfe.Sww.Ecf.Frontend.TagHelpers
 @using GovUk.Frontend.AspNetCore
-@using GovUk.Frontend.AspNetCore.TagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model Index
 
 @{
@@ -61,29 +56,14 @@
                 {
                     <tr class="govuk-table__row">
                         <td class="govuk-table__cell" data-test-class="account-name">
-                            <a title="View details of @account.FullName" class="govuk-link govuk-link--no-visited-state" asp-page="ViewAccountDetails" asp-route-id="@account.Id">@account.FullName</a>
+                            <a title="View details of @account.FullName" class="govuk-link govuk-link--no-visited-state"
+                               asp-page="ViewAccountDetails" asp-route-id="@account.Id">@account.FullName</a>
                         </td>
                         <td class="govuk-table__cell">
                             <account-types types="account.Types"/>
                         </td>
                         <td class="govuk-table__cell">
-                            @{
-                                var tagClass = account.Status switch
-                                {
-                                    AccountStatus.Active => "govuk-tag--green",
-                                    AccountStatus.PendingRegistration => "govuk-tag--orange",
-                                    _ => "govuk-tag--yellow"
-                                };
-                            }
-                            @if (account.Status is not null)
-                            {
-                                <strong class="govuk-tag @tagClass" data-test-class="account-status">
-                                    @account.Status.GetDisplayName()
-                                </strong>
-                                <span class="govuk-!-display-block govuk-hint govuk-!-margin-bottom-0 govuk-!-margin-top-1">
-                                    @account.Status.GetDescription()
-                                </span>
-                            }
+                            <account-status status="account.Status"/>
                         </td>
                     </tr>
                 }
@@ -93,7 +73,7 @@
             @if (paging?.PageCount > 1)
             {
                 <govuk-pagination>
-                    @if (paging?.Links?["previous"] != null && paging.Page != 1)
+                    @if (paging.Links?["previous"] != null && paging.Page != 1)
                     {
                         var prev = paging.Links["previous"];
                         <govuk-pagination-previous href="@LinkGenerator.ManageAccounts(prev.Offset, prev.PageSize)"/>
@@ -120,4 +100,4 @@
             }
         }
     </div>
-</div >
+</div>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/ViewAccountDetails.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/ViewAccountDetails.cshtml
@@ -13,6 +13,10 @@
             Change details
         </h1>
 
+        <div class="govuk-!-margin-bottom-6">
+            <account-status status="@Model.Account.Status"/>
+        </div>
+
         <govuk-summary-list>
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.Account.Types)</govuk-summary-list-row-key>

--- a/apps/user-management/apps/frontend/TagHelpers/AccountStatusTagHelper.cs
+++ b/apps/user-management/apps/frontend/TagHelpers/AccountStatusTagHelper.cs
@@ -1,0 +1,28 @@
+using Dfe.Sww.Ecf.Frontend.Extensions;
+using Dfe.Sww.Ecf.Frontend.Models;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Dfe.Sww.Ecf.Frontend.TagHelpers;
+
+public class AccountStatusTagHelper : TagHelper
+{
+    public AccountStatus? Status { get; set; }
+
+    public override void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        output.TagName = null;
+
+        if (Status == null) return;
+
+        var tagClass = Status switch
+        {
+            AccountStatus.Active => "govuk-tag--green",
+            AccountStatus.PendingRegistration => "govuk-tag--grey",
+            AccountStatus.Inactive => "govuk-tag--yellow",
+            _ => "govuk-tag--grey"
+        };
+
+        output.Content.SetHtmlContent(
+            $"<strong class=\"govuk-tag {tagClass}\" data-test-class=\"account-status\">{Status.GetDisplayName()}</strong>");
+    }
+}


### PR DESCRIPTION
- Adds the current user status to the view details page:
![Screenshot_20250617_162617](https://github.com/user-attachments/assets/278a6e5d-f624-4df0-aaaf-cce0e4964b11)
- Updates the status colours to match what is currently in the prototype:
![Screenshot_20250617_162814](https://github.com/user-attachments/assets/0ed5304c-6147-4cc2-ae75-ffed217989fb)
- Deletes the no-longer used `Paused` status from the auth service
- Adds the `Inactive` status back to the frontend to ensure parity with the prototype
