### PR TITLE
SWIP-683 Change user details journey flows on add user

### DIFF
--- a/apps/user-management/apps/frontend.Test/UnitTests/Helpers/FakeLinkGenerator.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Helpers/FakeLinkGenerator.cs
@@ -31,7 +31,8 @@ public class FakeLinkGenerator()
     protected override string GetRequiredPathByPage(
         string page,
         string? handler = null,
-        object? routeValues = null
+        object? routeValues = null,
+        FragmentString? fragment = null
     )
     {
         const string indexPath = "/index";
@@ -50,6 +51,9 @@ public class FakeLinkGenerator()
 
         if (routeValues is not null)
             generatedLink = AddRouteValues(generatedLink, routeValues);
+
+        if  (fragment is not null)
+            generatedLink = AddFragment(generatedLink, (FragmentString)fragment);
 
         return handler is null
             ? generatedLink
@@ -79,6 +83,11 @@ public class FakeLinkGenerator()
             : QueryHelpers.AddQueryString(generatedLink, "handler", handler);
 
         return httpContext.Request.Scheme + "://" + httpContext.Request.Host + generatedLink;
+    }
+
+    private static string AddFragment(string link, FragmentString fragment)
+    {
+        return link + fragment;
     }
 
     private static string AddRouteValues(string link, object routeValues)

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/AddAccountDetailsPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/AddAccountDetailsPageTests.cs
@@ -238,5 +238,6 @@ public class AddAccountDetailsPageTests : ManageAccountsPageTestBase<AddAccountD
 
         // Assert
         Sut.BackLinkPath.Should().Be("/manage-accounts/confirm-account-details");
+        Sut.FromChangeLink.Should().BeTrue();
     }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityFundingAvailablePageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityFundingAvailablePageTests.cs
@@ -27,6 +27,23 @@ public class EligibilityFundingAvailablePageTests : ManageAccountsPageTestBase<E
         // Assert
         result.Should().BeOfType<PageResult>();
         Sut.BackLinkPath.Should().Be("/manage-accounts/eligibility-qualification");
+        Sut.NextPagePath.Should().Be("/manage-accounts/add-account-details");
+        Sut.FromChangeLink.Should().BeFalse();
+
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public void OnGetChange_WhenCalled_LoadsTheViewWithNextPageConfirmAccountDetails()
+    {
+        // Act
+        var result = Sut.OnGetChange();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+
+        Sut.FromChangeLink.Should().BeTrue();
+        Sut.NextPagePath.Should().Be("/manage-accounts/confirm-account-details");
 
         VerifyAllNoOtherCalls();
     }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityFundingNotAvailablePageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityFundingNotAvailablePageTests.cs
@@ -32,6 +32,24 @@ public class EligibilityFundingNotAvailablePageTests : ManageAccountsPageTestBas
         // Assert
         result.Should().BeOfType<PageResult>();
         Sut.BackLinkPath.Should().Be(expectedBackLink);
+        Sut.NextPagePath.Should().Be("/manage-accounts/add-account-details");
+        Sut.FromChangeLink.Should().BeFalse();
+
+        MockCreateAccountJourneyService.Verify(x => x.GetIsAgencyWorker(), Times.Once);
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public void OnGetChange_WhenCalled_LoadsTheViewWithNextPageConfirmAccountDetails()
+    {
+        // Act
+        var result = Sut.OnGetChange();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+
+        Sut.FromChangeLink.Should().BeTrue();
+        Sut.NextPagePath.Should().Be("/manage-accounts/confirm-account-details");
 
         MockCreateAccountJourneyService.Verify(x => x.GetIsAgencyWorker(), Times.Once);
         VerifyAllNoOtherCalls();

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityQualificationPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityQualificationPageTests.cs
@@ -122,4 +122,53 @@ public class EligibilityQualificationPageTests : ManageAccountsPageTestBase<Elig
 
         VerifyAllNoOtherCalls();
     }
+
+    [Theory]
+    [InlineData(true, "/manage-accounts/eligibility-funding-available?handler=Change")]
+    [InlineData(false, "/manage-accounts/eligibility-funding-not-available?handler=Change")]
+    public async Task
+        OnPostAsync_WhenCalledFromChangeLink_RedirectsToRelevantPage(bool isRecentlyQualified, string redirectPath)
+    {
+        // Arrange
+        Sut.FromChangeLink = true;
+        Sut.IsRecentlyQualified = isRecentlyQualified;
+
+        // Act
+        var result = await Sut.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<RedirectResult>();
+        var redirectResult = result as RedirectResult;
+        redirectResult.Should().NotBeNull();
+        redirectResult!.Url.Should().Be(redirectPath);
+
+        MockCreateAccountJourneyService.Verify(x => x.SetIsRecentlyQualified(isRecentlyQualified), Times.Once);
+
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public void OnGetChange_WhenCalled_LoadsTheView()
+    {
+        // Act
+        var result = Sut.OnGetChange();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+
+        Sut.BackLinkPath.Should().Be("/manage-accounts/eligibility-agency-worker?handler=Change");
+        Sut.FromChangeLink.Should().BeTrue();
+        MockCreateAccountJourneyService.Verify(x => x.GetIsRecentlyQualified(), Times.Once);
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task OnPostChangeAsync_WhenCalled_HasFromChangeLinkTrue()
+    {
+        // Act
+        _ = await Sut.OnPostChangeAsync();
+
+        // Assert
+        Sut.FromChangeLink.Should().BeTrue();
+    }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilitySocialWorkEnglandDropoutPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilitySocialWorkEnglandDropoutPageTests.cs
@@ -29,7 +29,21 @@ public class EligibilitySocialWorkEnglandDropoutPageTests : ManageAccountsPageTe
         // Assert
         result.Should().BeOfType<PageResult>();
         Sut.BackLinkPath.Should().Be("/manage-accounts/eligibility-social-work-england");
+        Sut.FromChangeLink.Should().BeFalse();
+        VerifyAllNoOtherCalls();
+    }
 
+    [Fact]
+    public void OnGetChange_WhenCalled_LoadsTheView()
+    {
+        // Act
+        var result = Sut.OnGetChange();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+
+        Sut.BackLinkPath.Should().Be("/manage-accounts/eligibility-social-work-england?handler=Change");
+        Sut.FromChangeLink.Should().BeTrue();
         VerifyAllNoOtherCalls();
     }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilitySocialWorkEnglandPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilitySocialWorkEnglandPageTests.cs
@@ -32,6 +32,7 @@ public class EligibilitySocialWorkEnglandPageTests : ManageAccountsPageTestBase<
         result.Should().BeOfType<PageResult>();
 
         Sut.BackLinkPath.Should().Be("/manage-accounts/eligibility-information");
+        Sut.FromChangeLink.Should().BeFalse();
         MockCreateAccountJourneyService.Verify(x => x.GetIsRegisteredWithSocialWorkEngland(), Times.Once);
         VerifyAllNoOtherCalls();
     }
@@ -122,5 +123,54 @@ public class EligibilitySocialWorkEnglandPageTests : ManageAccountsPageTestBase<
         MockCreateAccountJourneyService.Verify(x => x.SetIsRegisteredWithSocialWorkEngland(false), Times.Once);
 
         VerifyAllNoOtherCalls();
+    }
+
+    [Theory]
+    [InlineData(true, "/manage-accounts/confirm-account-details")]
+    [InlineData(false, "/manage-accounts/eligibility-social-work-england-dropout?handler=Change")]
+    public async Task
+        OnPostAsync_WhenCalledFromChangeLink_RedirectsToRelevantPage(bool isRegisteredWithSocialWorkEngland, string redirectPath)
+    {
+        // Arrange
+        Sut.FromChangeLink = true;
+        Sut.IsRegisteredWithSocialWorkEngland = isRegisteredWithSocialWorkEngland;
+
+        // Act
+        var result = await Sut.OnPostAsync();
+
+        // Assert
+        result.Should().BeOfType<RedirectResult>();
+        var redirectResult = result as RedirectResult;
+        redirectResult.Should().NotBeNull();
+        redirectResult!.Url.Should().Be(redirectPath);
+
+        MockCreateAccountJourneyService.Verify(x => x.SetIsRegisteredWithSocialWorkEngland(isRegisteredWithSocialWorkEngland), Times.Once);
+
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public void OnGetChange_WhenCalled_LoadsTheView()
+    {
+        // Act
+        var result = Sut.OnGetChange();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+
+        Sut.BackLinkPath.Should().Be("/manage-accounts/confirm-account-details");
+        Sut.FromChangeLink.Should().BeTrue();
+        MockCreateAccountJourneyService.Verify(x => x.GetIsRegisteredWithSocialWorkEngland(), Times.Once);
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task OnPostChangeAsync_WhenCalled_HasFromChangeLinkTrue()
+    {
+        // Act
+        _ = await Sut.OnPostChangeAsync();
+
+        // Assert
+        Sut.FromChangeLink.Should().BeTrue();
     }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityStatutoryWorkDropoutPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityStatutoryWorkDropoutPageTests.cs
@@ -29,7 +29,22 @@ public class EligibilityStatutoryWorkDropoutPageTests : ManageAccountsPageTestBa
         // Assert
         result.Should().BeOfType<PageResult>();
         Sut.BackLinkPath.Should().Be("/manage-accounts/eligibility-statutory-work");
+        Sut.FromChangeLink.Should().BeFalse();
 
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public void OnGetChange_WhenCalled_LoadsTheView()
+    {
+        // Act
+        var result = Sut.OnGetChange();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+
+        Sut.BackLinkPath.Should().Be("/manage-accounts/eligibility-statutory-work?handler=Change");
+        Sut.FromChangeLink.Should().BeTrue();
         VerifyAllNoOtherCalls();
     }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/CreateAccountJourneyServiceTests/GetAccountChangeLinksShould.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/CreateAccountJourneyServiceTests/GetAccountChangeLinksShould.cs
@@ -14,13 +14,17 @@ public class GetAccountChangeLinksShould : CreateAccountJourneyServiceTestBase
         // Arrange
         var expectedChangeLinks = new AccountChangeLinks
         {
-            SelectedAccountChangeLink                 = "/manage-accounts/select-account-type",
-            RegisteredWithSocialWorkEnglandChangeLink = "/manage-accounts/eligibility-social-work-england",
-            StatutoryWorkerChangeLink                 = "/manage-accounts/eligibility-statutory-work",
-            AgencyWorkerChangeLink                    = "/manage-accounts/eligibility-agency-worker",
-            RecentlyQualifiedChangeLink               = "/manage-accounts/eligibility-qualification",
-            CoreDetailsChangeLink                     = "/manage-accounts/add-account-details?handler=Change",
-            ProgrammeDatesChangeLink                  = "/manage-accounts/social-worker-programme-dates"
+            SelectedAccountChangeLink = "/manage-accounts/select-account-type?handler=Change",
+            RegisteredWithSocialWorkEnglandChangeLink = "/manage-accounts/eligibility-social-work-england?handler=Change",
+            StatutoryWorkerChangeLink = "/manage-accounts/eligibility-statutory-work?handler=Change",
+            AgencyWorkerChangeLink = "/manage-accounts/eligibility-agency-worker?handler=Change",
+            RecentlyQualifiedChangeLink = "/manage-accounts/eligibility-qualification?handler=Change",
+            FirstNameChangeLink = "/manage-accounts/add-account-details?handler=Change#FirstName",
+            MiddleNamesChangeLink = "/manage-accounts/add-account-details?handler=Change#MiddleNames",
+            LastNameChangeLink = "/manage-accounts/add-account-details?handler=Change#LastName",
+            EmailChangeLink = "/manage-accounts/add-account-details?handler=Change#Email",
+            SocialWorkEnglandNumberChangeLink = "/manage-accounts/add-account-details?handler=Change#SocialWorkEnglandNumber",
+            ProgrammeDatesChangeLink = "/manage-accounts/social-worker-programme-dates"
         };
 
         // Act

--- a/apps/user-management/apps/frontend/Models/AccountChangeLinks.cs
+++ b/apps/user-management/apps/frontend/Models/AccountChangeLinks.cs
@@ -7,6 +7,10 @@ public class AccountChangeLinks
     public string? StatutoryWorkerChangeLink { get; set; }
     public string? AgencyWorkerChangeLink { get; set; }
     public string? RecentlyQualifiedChangeLink { get; set; }
-    public string? CoreDetailsChangeLink { get; set; }
+    public string? FirstNameChangeLink { get; set; }
+    public string? MiddleNamesChangeLink { get; set; }
+    public string? LastNameChangeLink { get; set; }
+    public string? EmailChangeLink { get; set; }
+    public string? SocialWorkEnglandNumberChangeLink { get; set; }
     public string? ProgrammeDatesChangeLink { get; set; }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/AddAccountDetails.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/AddAccountDetails.cshtml.cs
@@ -109,11 +109,12 @@ public class AddAccountDetails(
 
         createAccountJourneyService.SetAccountDetails(accountDetails);
 
-        return Redirect(IsStaff ? linkGenerator.ConfirmAccountDetails() : linkGenerator.SocialWorkerProgrammeDates());
+        return Redirect((IsStaff || FromChangeLink) ? linkGenerator.ConfirmAccountDetails() : linkGenerator.SocialWorkerProgrammeDates());
     }
 
     public async Task<IActionResult> OnPostChangeAsync()
     {
+        FromChangeLink = true;
         SetBackLinkPath(true);
         return await OnPostAsync();
     }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/ConfirmAccountDetails.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/ConfirmAccountDetails.cshtml
@@ -19,7 +19,8 @@
                     <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.SelectedAccountType)</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.SelectedAccountType</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.SelectedAccountChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.SelectedAccountType)">
+                        <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.SelectedAccountChangeLink"
+                                                       visually-hidden-text="@Html.DisplayNameFor(model => model.SelectedAccountType)">
                             Change
                         </govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
@@ -31,7 +32,8 @@
                         <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.RegisteredWithSocialWorkEngland)</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value>@Model.RegisteredWithSocialWorkEngland</govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.RegisteredWithSocialWorkEnglandChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.RegisteredWithSocialWorkEngland)">
+                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.RegisteredWithSocialWorkEnglandChangeLink"
+                                                           visually-hidden-text="@Html.DisplayNameFor(model => model.RegisteredWithSocialWorkEngland)">
                                 Change
                             </govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
@@ -44,7 +46,8 @@
                         <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.StatutoryWorker)</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value>@Model.StatutoryWorker</govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.StatutoryWorkerChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.StatutoryWorker)">
+                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.StatutoryWorkerChangeLink"
+                                                           visually-hidden-text="@Html.DisplayNameFor(model => model.StatutoryWorker)">
                                 Change
                             </govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
@@ -57,7 +60,8 @@
                         <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.AgencyWorker)</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value>@Model.AgencyWorker</govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.AgencyWorkerChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.AgencyWorker)">
+                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.AgencyWorkerChangeLink"
+                                                           visually-hidden-text="@Html.DisplayNameFor(model => model.AgencyWorker)">
                                 Change
                             </govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
@@ -70,7 +74,8 @@
                         <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.Qualified)</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value>@Model.Qualified</govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.RecentlyQualifiedChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.Qualified)">
+                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.RecentlyQualifiedChangeLink"
+                                                           visually-hidden-text="@Html.DisplayNameFor(model => model.Qualified)">
                                 Change
                             </govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
@@ -81,7 +86,8 @@
                     <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.FirstName)</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.FirstName</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.CoreDetailsChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.FirstName)">Change
+                        <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.FirstNameChangeLink"
+                                                       visually-hidden-text="@Html.DisplayNameFor(model => model.FirstName)">Change
                         </govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
@@ -92,7 +98,8 @@
                         <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.MiddleNames)</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value>@Model.MiddleNames</govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.CoreDetailsChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.MiddleNames)">Change
+                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.MiddleNamesChangeLink"
+                                                           visually-hidden-text="@Html.DisplayNameFor(model => model.MiddleNames)">Change
                             </govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
                     </govuk-summary-list-row>
@@ -104,7 +111,8 @@
                     </govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.LastName</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.CoreDetailsChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.LastName)">
+                        <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.LastNameChangeLink"
+                                                       visually-hidden-text="@Html.DisplayNameFor(model => model.LastName)">
                             Change
                         </govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
@@ -116,53 +124,52 @@
                     </govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.Email</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.CoreDetailsChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.Email)">Change
+                        <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.EmailChangeLink"
+                                                       visually-hidden-text="@Html.DisplayNameFor(model => model.Email)">Change
                         </govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
-            </govuk-summary-list>
 
-            @if (Model.SocialWorkEnglandNumber is not null)
-            {
-                <govuk-summary-list>
+                @if (Model.SocialWorkEnglandNumber is not null)
+                {
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.SocialWorkEnglandNumber)</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value>@Model.SocialWorkEnglandNumber</govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.CoreDetailsChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.SocialWorkEnglandNumber)">Change
+                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.SocialWorkEnglandNumberChangeLink"
+                                                           visually-hidden-text="@Html.DisplayNameFor(model => model.SocialWorkEnglandNumber)">Change
                             </govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
                     </govuk-summary-list-row>
-                </govuk-summary-list>
-            }
+                }
 
-            @if (Model.ProgrammeStartDate is not null && Model.IsStaff is false)
-            {
-                <govuk-summary-list>
+                @if (Model.ProgrammeStartDate is not null && Model.IsStaff is false)
+                {
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.ProgrammeStartDate)</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value>@Model.ProgrammeStartDate</govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.ProgrammeDatesChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.ProgrammeStartDate)">Change
+                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.ProgrammeDatesChangeLink"
+                                                           visually-hidden-text="@Html.DisplayNameFor(model => model.ProgrammeStartDate)">Change
                             </govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
                     </govuk-summary-list-row>
-                </govuk-summary-list>
-            }
+                }
 
-            @if (Model.ProgrammeEndDate is not null && Model.IsStaff is false)
-            {
-                <govuk-summary-list>
+                @if (Model.ProgrammeEndDate is not null && Model.IsStaff is false)
+                {
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.ProgrammeEndDate)</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value>@Model.ProgrammeEndDate</govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.ProgrammeDatesChangeLink" visually-hidden-text="@Html.DisplayNameFor(model => model.ProgrammeEndDate)">Change
+                            <govuk-summary-list-row-action href="@Model.ChangeDetailsLinks.ProgrammeDatesChangeLink"
+                                                           visually-hidden-text="@Html.DisplayNameFor(model => model.ProgrammeEndDate)">Change
                             </govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
                     </govuk-summary-list-row>
-                </govuk-summary-list>
-            }
+                }
+
+            </govuk-summary-list>
 
             <h2 class="govuk-heading-m">What happens next</h2>
 

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityAgencyWorker.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityAgencyWorker.cshtml.cs
@@ -23,7 +23,7 @@ public class EligibilityAgencyWorker(
 
     public PageResult OnGet()
     {
-        BackLinkPath = linkGenerator.EligibilityStatutoryWork();
+        BackLinkPath = FromChangeLink ? linkGenerator.ConfirmAccountDetails() : linkGenerator.EligibilityStatutoryWork();
         IsAgencyWorker = createAccountJourneyService.GetIsAgencyWorker();
         return Page();
     }
@@ -38,15 +38,37 @@ public class EligibilityAgencyWorker(
             return Page();
         }
 
+        var previousIsAgencyWorkerValue = createAccountJourneyService.GetIsAgencyWorker();
         createAccountJourneyService.SetIsAgencyWorker(IsAgencyWorker);
 
         if (IsAgencyWorker is true)
         {
             createAccountJourneyService.SetIsRecentlyQualified(null);
+            if (FromChangeLink)
+            {
+                if (previousIsAgencyWorkerValue == true)
+                {
+                    return Redirect(linkGenerator.ConfirmAccountDetails());
+                }
+                return Redirect(linkGenerator.EligibilityFundingNotAvailableChange());
+            }
+            return Redirect(linkGenerator.EligibilityFundingNotAvailable());
         }
 
-        return Redirect(IsAgencyWorker is false
-            ? linkGenerator.EligibilityQualification()
-            : linkGenerator.EligibilityFundingNotAvailable());
+        return Redirect(FromChangeLink
+            ? linkGenerator.EligibilityQualificationChange()
+            : linkGenerator.EligibilityQualification());
+    }
+
+    public PageResult OnGetChange()
+    {
+        FromChangeLink = true;
+        return OnGet();
+    }
+
+    public async Task<IActionResult> OnPostChangeAsync()
+    {
+        FromChangeLink = true;
+        return await OnPostAsync();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingAvailable.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingAvailable.cshtml
@@ -15,7 +15,7 @@
 
             <p>Once you have entered their details, we will send the social worker an email inviting them to log into the digital service and complete their registration.</p>
 
-            <govuk-button-link href="@LinkGenerator.AddAccountDetails()">Continue</govuk-button-link>
+            <govuk-button-link href="@Model.NextPagePath">Continue</govuk-button-link>
         </div>
     </div>
 </div>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingAvailable.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingAvailable.cshtml.cs
@@ -11,9 +11,17 @@ namespace Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
 [AuthorizeRoles(RoleType.Coordinator)]
 public class EligibilityFundingAvailable(EcfLinkGenerator linkGenerator) : BasePageModel
 {
+    public string? NextPagePath { get; set; }
     public PageResult OnGet()
     {
         BackLinkPath = linkGenerator.EligibilityQualification();
+        NextPagePath = FromChangeLink ? linkGenerator.ConfirmAccountDetails() : linkGenerator.AddAccountDetails();
         return Page();
+    }
+
+    public PageResult OnGetChange()
+    {
+        FromChangeLink = true;
+        return OnGet();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingNotAvailable.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingNotAvailable.cshtml
@@ -20,7 +20,7 @@
 
             <p>You can still register the social worker on this service. They will be able to access the learning, development and assessment materials.</p>
 
-            <govuk-button-link href="@LinkGenerator.AddAccountDetails()">Continue</govuk-button-link>
+            <govuk-button-link href="@Model.NextPagePath">Continue</govuk-button-link>
         </div>
     </div>
 </div>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingNotAvailable.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingNotAvailable.cshtml.cs
@@ -14,11 +14,19 @@ public class EligibilityFundingNotAvailable(
     ICreateAccountJourneyService createAccountJourneyService,
     EcfLinkGenerator linkGenerator) : BasePageModel
 {
+    public string? NextPagePath { get; set; }
     public PageResult OnGet()
     {
         BackLinkPath = createAccountJourneyService.GetIsAgencyWorker() == true
             ? linkGenerator.EligibilityAgencyWorker()
             : linkGenerator.EligibilityQualification();
+        NextPagePath = FromChangeLink ? linkGenerator.ConfirmAccountDetails() : linkGenerator.AddAccountDetails();
         return Page();
+    }
+
+    public PageResult OnGetChange()
+    {
+        FromChangeLink = true;
+        return OnGet();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityQualification.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityQualification.cshtml.cs
@@ -26,7 +26,7 @@ public class EligibilityQualification(
 
     public PageResult OnGet()
     {
-        BackLinkPath = linkGenerator.EligibilityAgencyWorker();
+        BackLinkPath = FromChangeLink ? linkGenerator.EligibilityAgencyWorkerChange() : linkGenerator.EligibilityAgencyWorker();
         IsRecentlyQualified = createAccountJourneyService.GetIsRecentlyQualified();
         return Page();
     }
@@ -42,9 +42,27 @@ public class EligibilityQualification(
         }
 
         createAccountJourneyService.SetIsRecentlyQualified(IsRecentlyQualified);
+        if (FromChangeLink)
+        {
+            return Redirect(IsRecentlyQualified is false
+                ? linkGenerator.EligibilityFundingNotAvailableChange()
+                : linkGenerator.EligibilityFundingAvailableChange());
+        }
 
         return Redirect(IsRecentlyQualified is false
             ? linkGenerator.EligibilityFundingNotAvailable()
             : linkGenerator.EligibilityFundingAvailable());
+    }
+
+    public PageResult OnGetChange()
+    {
+        FromChangeLink = true;
+        return OnGet();
+    }
+
+    public async Task<IActionResult> OnPostChangeAsync()
+    {
+        FromChangeLink = true;
+        return await OnPostAsync();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEngland.cshtml.cs
@@ -23,7 +23,7 @@ public class EligibilitySocialWorkEngland(
 
     public PageResult OnGet()
     {
-        BackLinkPath = linkGenerator.EligibilityInformation();
+        BackLinkPath = FromChangeLink ? linkGenerator.ConfirmAccountDetails() : linkGenerator.EligibilityInformation();
         IsRegisteredWithSocialWorkEngland = createAccountJourneyService.GetIsRegisteredWithSocialWorkEngland();
         return Page();
     }
@@ -39,9 +39,28 @@ public class EligibilitySocialWorkEngland(
         }
 
         createAccountJourneyService.SetIsRegisteredWithSocialWorkEngland(IsRegisteredWithSocialWorkEngland);
-
+        if (FromChangeLink)
+        {
+            if (IsRegisteredWithSocialWorkEngland == true)
+            {
+                return Redirect(linkGenerator.ConfirmAccountDetails());
+            }
+            return Redirect(linkGenerator.EligibilitySocialWorkEnglandDropoutChange());
+        }
         return Redirect(IsRegisteredWithSocialWorkEngland is false
             ? linkGenerator.EligibilitySocialWorkEnglandDropout()
             : linkGenerator.EligibilityStatutoryWork());
+    }
+
+    public PageResult OnGetChange()
+    {
+        FromChangeLink = true;
+        return OnGet();
+    }
+
+    public async Task<IActionResult> OnPostChangeAsync()
+    {
+        FromChangeLink = true;
+        return await OnPostAsync();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEnglandDropout.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilitySocialWorkEnglandDropout.cshtml.cs
@@ -13,7 +13,13 @@ public class EligibilitySocialWorkEnglandDropout(EcfLinkGenerator linkGenerator)
 {
     public PageResult OnGet()
     {
-        BackLinkPath = linkGenerator.EligibilitySocialWorkEngland();
+        BackLinkPath = FromChangeLink ? linkGenerator.EligibilitySocialWorkEnglandChange() : linkGenerator.EligibilitySocialWorkEngland();
         return Page();
+    }
+
+    public PageResult OnGetChange()
+    {
+        FromChangeLink = true;
+        return OnGet();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityStatutoryWork.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityStatutoryWork.cshtml.cs
@@ -23,7 +23,7 @@ public class EligibilityStatutoryWork(
 
     public PageResult OnGet()
     {
-        BackLinkPath = linkGenerator.EligibilitySocialWorkEngland();
+        BackLinkPath = FromChangeLink ? linkGenerator.ConfirmAccountDetails() : linkGenerator.EligibilitySocialWorkEngland();
         IsStatutoryWorker = createAccountJourneyService.GetIsStatutoryWorker();
         return Page();
     }
@@ -40,8 +40,28 @@ public class EligibilityStatutoryWork(
 
         createAccountJourneyService.SetIsStatutoryWorker(IsStatutoryWorker);
 
+        if (FromChangeLink)
+        {
+            if (IsStatutoryWorker == true)
+            {
+                return Redirect(linkGenerator.ConfirmAccountDetails());
+            }
+            return Redirect(linkGenerator.EligibilityStatutoryWorkDropoutChange());
+        }
         return Redirect(IsStatutoryWorker is false
             ? linkGenerator.EligibilityStatutoryWorkDropout()
             : linkGenerator.EligibilityAgencyWorker());
+    }
+
+    public PageResult OnGetChange()
+    {
+        FromChangeLink = true;
+        return OnGet();
+    }
+
+    public async Task<IActionResult> OnPostChangeAsync()
+    {
+        FromChangeLink = true;
+        return await OnPostAsync();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityStatutoryWorkDropout.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityStatutoryWorkDropout.cshtml.cs
@@ -13,7 +13,13 @@ public class EligibilityStatutoryWorkDropout(EcfLinkGenerator linkGenerator) : B
 {
     public PageResult OnGet()
     {
-        BackLinkPath = linkGenerator.EligibilityStatutoryWork();
+        BackLinkPath = FromChangeLink ? linkGenerator.EligibilityStatutoryWorkChange() : linkGenerator.EligibilityStatutoryWork();
         return Page();
+    }
+
+    public PageResult OnGetChange()
+    {
+        FromChangeLink = true;
+        return OnGet();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml
@@ -9,7 +9,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <form method="post" asp-page-handler="@(Model.EditAccountId is not null ? "Edit" : "")">
+        <form method="post" asp-page-handler="@Model.Handler">
             <govuk-radios for="IsStaff">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l">

--- a/apps/user-management/apps/frontend/Pages/Shared/BasePageModel.cs
+++ b/apps/user-management/apps/frontend/Pages/Shared/BasePageModel.cs
@@ -7,4 +7,6 @@ public class BasePageModel : PageModel
     public string? Title { get; set; }
 
     public string? BackLinkPath { get; set; }
+
+    public bool FromChangeLink { get; set; }
 }

--- a/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
+++ b/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
@@ -39,11 +39,44 @@ public abstract class EcfLinkGenerator(
 
     public string AddAccountDetails() => GetRequiredPathByPage("/ManageAccounts/AddAccountDetails");
 
-    public string AddAccountDetailsChange() =>
-        GetRequiredPathByPage("/ManageAccounts/AddAccountDetails", handler: "Change");
+    public string AddAccountDetailsChange() => GetRequiredPathByPage("/ManageAccounts/AddAccountDetails", handler: "Change");
 
-    public string EditAccountDetails(Guid id) =>
-        GetRequiredPathByPage("/ManageAccounts/EditAccountDetails", routeValues: new { id });
+    public string AddAccountDetailsChangeFirstName() =>
+        GetRequiredPathByPage(
+            "/ManageAccounts/AddAccountDetails",
+            handler: "Change",
+            fragment: new FragmentString("#FirstName")
+        );
+
+    public string AddAccountDetailsChangeMiddleNames() =>
+        GetRequiredPathByPage(
+            "/ManageAccounts/AddAccountDetails",
+            handler: "Change",
+            fragment: new FragmentString("#MiddleNames")
+        );
+
+    public string AddAccountDetailsChangeLastName() =>
+        GetRequiredPathByPage(
+            "/ManageAccounts/AddAccountDetails",
+            handler: "Change",
+            fragment: new FragmentString("#LastName")
+        );
+
+    public string AddAccountDetailsChangeEmail() =>
+        GetRequiredPathByPage(
+            "/ManageAccounts/AddAccountDetails",
+            handler: "Change",
+            fragment: new FragmentString("#Email")
+        );
+
+    public string AddAccountDetailsChangeSocialWorkEnglandNumber() =>
+        GetRequiredPathByPage(
+            "/ManageAccounts/AddAccountDetails",
+            handler: "Change",
+            fragment: new FragmentString("#SocialWorkEnglandNumber")
+        );
+
+    public string EditAccountDetails(Guid id) => GetRequiredPathByPage("/ManageAccounts/EditAccountDetails", routeValues: new { id });
 
     public string EditAccountDetailsChange(Guid id) =>
         GetRequiredPathByPage(
@@ -64,18 +97,30 @@ public abstract class EcfLinkGenerator(
 
     public string ViewAccountDetails(Guid id) => GetRequiredPathByPage("/ManageAccounts/ViewAccountDetails", routeValues: new { id });
     public string SelectAccountType() => GetRequiredPathByPage("/ManageAccounts/SelectAccountType");
+
+    public string SelectAccountTypeChange() =>
+        GetRequiredPathByPage("/ManageAccounts/SelectAccountType", handler: "Change");
+
     public string AddSomeoneNew() => GetRequiredPathByPage("/ManageAccounts/SelectAccountType", handler: "New");
     public string SelectUseCase() => GetRequiredPathByPage("/ManageAccounts/SelectUseCase");
     public string AddExistingUser() => GetRequiredPathByPage("/ManageAccounts/AddExistingUser");
     public string EligibilityInformation() => GetRequiredPathByPage("/ManageAccounts/EligibilityInformation");
     public string EligibilitySocialWorkEngland() => GetRequiredPathByPage("/ManageAccounts/EligibilitySocialWorkEngland");
+    public string EligibilitySocialWorkEnglandChange() => GetRequiredPathByPage("/ManageAccounts/EligibilitySocialWorkEngland", handler: "Change");
     public string EligibilitySocialWorkEnglandDropout() => GetRequiredPathByPage("/ManageAccounts/EligibilitySocialWorkEnglandDropout");
+    public string EligibilitySocialWorkEnglandDropoutChange() => GetRequiredPathByPage("/ManageAccounts/EligibilitySocialWorkEnglandDropout", handler: "Change");
     public string EligibilityStatutoryWork() => GetRequiredPathByPage("/ManageAccounts/EligibilityStatutoryWork");
+    public string EligibilityStatutoryWorkChange() => GetRequiredPathByPage("/ManageAccounts/EligibilityStatutoryWork", handler: "Change");
     public string EligibilityStatutoryWorkDropout() => GetRequiredPathByPage("/ManageAccounts/EligibilityStatutoryWorkDropout");
+    public string EligibilityStatutoryWorkDropoutChange() => GetRequiredPathByPage("/ManageAccounts/EligibilityStatutoryWorkDropout", handler: "Change");
     public string EligibilityAgencyWorker() => GetRequiredPathByPage("/ManageAccounts/EligibilityAgencyWorker");
+    public string EligibilityAgencyWorkerChange() => GetRequiredPathByPage("/ManageAccounts/EligibilityAgencyWorker", handler: "Change");
     public string EligibilityQualification() => GetRequiredPathByPage("/ManageAccounts/EligibilityQualification");
+    public string EligibilityQualificationChange() => GetRequiredPathByPage("/ManageAccounts/EligibilityQualification", handler: "Change");
     public string EligibilityFundingNotAvailable() => GetRequiredPathByPage("/ManageAccounts/EligibilityFundingNotAvailable");
+    public string EligibilityFundingNotAvailableChange() => GetRequiredPathByPage("/ManageAccounts/EligibilityFundingNotAvailable", handler: "Change");
     public string EligibilityFundingAvailable() => GetRequiredPathByPage("/ManageAccounts/EligibilityFundingAvailable");
+    public string EligibilityFundingAvailableChange() => GetRequiredPathByPage("/ManageAccounts/EligibilityFundingAvailable", handler: "Change");
     public string SocialWorkerProgrammeDates() => GetRequiredPathByPage("/ManageAccounts/SocialWorkerProgrammeDates");
 
     // SWE registration links
@@ -89,7 +134,10 @@ public abstract class EcfLinkGenerator(
     public string SocialWorkerRegistrationEthnicGroupBlack() => GetRequiredPathByPage("/SocialWorkerRegistration/SelectEthnicGroup/BlackAfricanCaribbeanOrBlackBritish");
     public string SocialWorkerRegistrationEthnicGroupOther() => GetRequiredPathByPage("/SocialWorkerRegistration/SelectEthnicGroup/OtherEthnicGroup");
     public string SocialWorkerRegistrationSelectDisability() => GetRequiredPathByPage("/SocialWorkerRegistration/SelectDisability");
-    public string SocialWorkerRegistrationSelectSocialWorkEnglandRegistrationDate() => GetRequiredPathByPage("/SocialWorkerRegistration/SelectSocialWorkEnglandRegistrationDate");
+
+    public string SocialWorkerRegistrationSelectSocialWorkEnglandRegistrationDate() =>
+        GetRequiredPathByPage("/SocialWorkerRegistration/SelectSocialWorkEnglandRegistrationDate");
+
     public string SocialWorkerRegistrationSelectHighestQualification() => GetRequiredPathByPage("/SocialWorkerRegistration/SelectHighestQualification");
     public string SocialWorkerRegistrationSelectSocialWorkQualificationEndYear() => GetRequiredPathByPage("/SocialWorkerRegistration/SelectSocialWorkQualificationEndYear");
     public string SocialWorkerRegistrationSelectRouteIntoSocialWork() => GetRequiredPathByPage("/SocialWorkerRegistration/SelectRouteIntoSocialWork");
@@ -99,7 +147,8 @@ public abstract class EcfLinkGenerator(
     protected abstract string GetRequiredPathByPage(
         string page,
         string? handler = null,
-        object? routeValues = null
+        object? routeValues = null,
+        FragmentString? fragment = null
     );
 
     protected abstract string GetRequiredUriByPage(
@@ -119,11 +168,12 @@ public class RoutingEcfLinkGenerator(
     protected override string GetRequiredPathByPage(
         string page,
         string? handler = null,
-        object? routeValues = null
+        object? routeValues = null,
+        FragmentString? fragment = null
     )
     {
-        return linkGenerator.GetPathByPage(page, handler, values: routeValues)
-            ?? throw new InvalidOperationException("Page was not found.");
+        return linkGenerator.GetPathByPage(page, handler, values: routeValues, pathBase: PathString.Empty, fragment: fragment ?? FragmentString.Empty)
+               ?? throw new InvalidOperationException("Page was not found.");
     }
 
     protected override string GetRequiredUriByPage(
@@ -134,6 +184,6 @@ public class RoutingEcfLinkGenerator(
     )
     {
         return linkGenerator.GetUriByPage(httpContext, page, handler, values: routeValues)
-            ?? throw new InvalidOperationException("Page was not found.");
+               ?? throw new InvalidOperationException("Page was not found.");
     }
 }

--- a/apps/user-management/apps/frontend/Services/Journeys/CreateAccountJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/CreateAccountJourneyService.cs
@@ -76,6 +76,10 @@ public class CreateAccountJourneyService(
     {
         var createAccountJourneyModel = GetCreateAccountJourneyModel();
         createAccountJourneyModel.IsStaff = isStaff;
+        if (createAccountJourneyModel.AccountDetails is not null && isStaff is not null)
+        {
+            createAccountJourneyModel.AccountDetails.IsStaff = (bool)isStaff;
+        }
         SetCreateAccountJourneyModel(createAccountJourneyModel);
     }
 
@@ -198,12 +202,16 @@ public class CreateAccountJourneyService(
     {
         return new AccountChangeLinks
         {
-            SelectedAccountChangeLink = linkGenerator.SelectAccountType(),
-            RegisteredWithSocialWorkEnglandChangeLink = linkGenerator.EligibilitySocialWorkEngland(),
-            StatutoryWorkerChangeLink = linkGenerator.EligibilityStatutoryWork(),
-            AgencyWorkerChangeLink = linkGenerator.EligibilityAgencyWorker(),
-            RecentlyQualifiedChangeLink = linkGenerator.EligibilityQualification(),
-            CoreDetailsChangeLink = linkGenerator.AddAccountDetailsChange(),
+            SelectedAccountChangeLink = linkGenerator.SelectAccountTypeChange(),
+            RegisteredWithSocialWorkEnglandChangeLink = linkGenerator.EligibilitySocialWorkEnglandChange(),
+            StatutoryWorkerChangeLink = linkGenerator.EligibilityStatutoryWorkChange(),
+            AgencyWorkerChangeLink = linkGenerator.EligibilityAgencyWorkerChange(),
+            RecentlyQualifiedChangeLink = linkGenerator.EligibilityQualificationChange(),
+            FirstNameChangeLink = linkGenerator.AddAccountDetailsChangeFirstName(),
+            MiddleNamesChangeLink = linkGenerator.AddAccountDetailsChangeMiddleNames(),
+            LastNameChangeLink = linkGenerator.AddAccountDetailsChangeLastName(),
+            EmailChangeLink = linkGenerator.AddAccountDetailsChangeEmail(),
+            SocialWorkEnglandNumberChangeLink = linkGenerator.AddAccountDetailsChangeSocialWorkEnglandNumber(),
             ProgrammeDatesChangeLink = linkGenerator.SocialWorkerProgrammeDates()
         };
     }


### PR DESCRIPTION
PR includes changes for [SWIP-683](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-683):
- page flow behaviour for selecting change links on the Check Details page when adding an ECSW
- unit tests
- changes to Check Details page to remove html elements that are not needed (causing extra padding)
- changes to Check Details page to focus on the relevant element on the Add details page (when change first name, email, etc.) is clicked