### PR TITLE
SWIP-629 Resend registration invite

### DIFF
--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/Services/Accounts/AccountsService.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/Services/Accounts/AccountsService.cs
@@ -41,7 +41,14 @@ public class AccountsService(EcfDbContext dbContext, IClock clock) : IAccountsSe
             .ThenInclude(pr => pr.Role)
             .FirstOrDefaultAsync(p => p.PersonId == id
                                       && p.DeletedOn.HasValue == false);
-        return account?.ToDto();
+        if (account == null)
+        {
+            return null;
+        }
+        var accountDto = account.ToDto();
+        accountDto.HasCompletedLoginAccountLinking = await dbContext.OneLoginUsers
+            .AnyAsync(o => o.PersonId == account!.PersonId);
+        return accountDto;
     }
 
     public async Task<PersonDto> CreateAsync(Person person)

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/Services/Accounts/PersonDto.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/Services/Accounts/PersonDto.cs
@@ -63,6 +63,8 @@ public class PersonDto
     public string? OtherRouteIntoSocialWork { get; set; }
 
     public int? SocialWorkQualificationEndYear { get; set; }
+
+    public bool HasCompletedLoginAccountLinking  { get; set; }
 }
 
 public static class PersonDtoExtensions

--- a/apps/user-management/apps/frontend.Test/UnitTests/Helpers/Builders/AccountBuilder.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Helpers/Builders/AccountBuilder.cs
@@ -50,6 +50,7 @@ public class AccountBuilder
         _faker.RuleFor(a => a.SocialWorkQualificationEndYear, f => f.Random.Number(1900, 2000));
         _faker.RuleFor(a => a.RouteIntoSocialWork, f => f.PickRandom<RouteIntoSocialWork>());
         _faker.RuleFor(a => a.OtherRouteIntoSocialWork, f => f.Name.FirstName());
+        _faker.RuleFor(a => a.HasCompletedLoginAccountLinking, f => f.Random.Bool());
     }
 
     public AccountBuilder WithAddOrEditAccountDetailsData()
@@ -287,6 +288,13 @@ public class AccountBuilder
     public AccountBuilder WithOtherRouteIntoSocialWork(string otherRouteIntoSocialWork)
     {
         _faker.RuleFor(a => a.OtherRouteIntoSocialWork, _ => otherRouteIntoSocialWork);
+
+        return this;
+    }
+
+    public AccountBuilder WithHasCompletedLoginAccountLinking(bool hasCompletedLoginAccountLinking)
+    {
+        _faker.RuleFor(a => a.HasCompletedLoginAccountLinking, _ => hasCompletedLoginAccountLinking);
 
         return this;
     }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Helpers/Fakers/PersonFaker.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Helpers/Fakers/PersonFaker.cs
@@ -15,5 +15,6 @@ public sealed class PersonFaker : Faker<Person>
         RuleFor(a => a.SocialWorkEnglandNumber, f => f.Random.Number().ToString());
         RuleFor(a => a.CreatedOn, f => f.Date.Past());
         RuleFor(a => a.Roles, f => [f.PickRandom<AccountType>()]);
+        RuleFor(a => a.HasCompletedLoginAccountLinking, f => f.Random.Bool());
     }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/ViewAccountDetailsPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/ViewAccountDetailsPageTests.cs
@@ -13,7 +13,11 @@ public class ViewAccountDetailsPageTests : ManageAccountsPageTestBase<ViewAccoun
 {
     public ViewAccountDetailsPageTests()
     {
-        Sut = new ViewAccountDetails(MockAccountService.Object, new FakeLinkGenerator())
+        Sut = new ViewAccountDetails(
+            MockAccountService.Object,
+            new FakeLinkGenerator(),
+            MockCreateAccountJourneyService.Object
+        )
         {
             TempData = TempData
         };

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/ViewAccountDetailsPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/ViewAccountDetailsPageTests.cs
@@ -3,6 +3,7 @@ using Dfe.Sww.Ecf.Frontend.Models;
 using Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
 using Dfe.Sww.Ecf.Frontend.Test.UnitTests.Helpers;
 using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Moq;
 using Xunit;
@@ -48,7 +49,10 @@ public class ViewAccountDetailsPageTests : ManageAccountsPageTestBase<ViewAccoun
     public async Task Get_WhenCalledWithSocialWorker_SetsIsSocialWorkerToTrue()
     {
         // Arrange
-        var account = AccountBuilder.WithTypes([AccountType.EarlyCareerSocialWorker]).Build();
+        var account = AccountBuilder
+            .WithTypes([AccountType.EarlyCareerSocialWorker])
+            .WithHasCompletedLoginAccountLinking(true)
+            .Build();
 
         MockAccountService.Setup(x => x.GetByIdAsync(account.Id)).ReturnsAsync(account);
 
@@ -60,6 +64,8 @@ public class ViewAccountDetailsPageTests : ManageAccountsPageTestBase<ViewAccoun
         Sut.Account.Should().BeEquivalentTo(account);
         Sut.IsSocialWorker.Should().BeTrue();
         Sut.IsAssessor.Should().BeFalse();
+        Sut.HasCompletedLoginAccountLinking.Should().BeTrue();
+        Sut.BackLinkPath.Should().Be("/manage-accounts");
 
         MockAccountService.Verify(x => x.GetByIdAsync(account.Id), Times.Once);
         MockAccountService.VerifyNoOtherCalls();
@@ -86,5 +92,63 @@ public class ViewAccountDetailsPageTests : ManageAccountsPageTestBase<ViewAccoun
 
         MockAccountService.Verify(x => x.GetByIdAsync(account.Id), Times.Once);
         MockAccountService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Post_WhenCalledWithAccountFound_ResendsInvitationEmailAndRedirectsToManageAccountsPage()
+    {
+        // Arrange
+        var account = AccountBuilder.Build();
+        var accountDetails = AccountDetails.FromAccount(account);
+
+        MockAccountService.Setup(x => x.GetByIdAsync(account.Id)).ReturnsAsync(account);
+
+        // Act
+        var result = await Sut.OnPostAsync(account.Id);
+
+        // Assert
+        result.Should().BeOfType<RedirectResult>();
+
+        var redirectResult = result as RedirectResult;
+        redirectResult.Should().NotBeNull();
+        redirectResult!
+            .Url.Should()
+            .Be("/manage-accounts");
+
+        MockAccountService.Verify(x => x.GetByIdAsync(account.Id), Times.Once);
+        MockCreateAccountJourneyService.Verify(x => x.SendInvitationEmailAsync(account), Times.Once);
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Post_WhenCalledAndNoAccountFound_ReturnsNotFoundResult()
+    {
+        // Arrange
+        var id = Guid.Empty;
+        MockAccountService.Setup(x => x.GetByIdAsync(id)).ReturnsAsync(default(Account));
+
+        // Act
+        var result = await Sut.OnPostAsync(id);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>();
+        MockAccountService.Verify(x => x.GetByIdAsync(id), Times.Once);
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task Get_WhenCalledAndNoAccountFound_ReturnsNotFoundResult()
+    {
+        // Arrange
+        var id = Guid.Empty;
+        MockAccountService.Setup(x => x.GetByIdAsync(id)).ReturnsAsync(default(Account));
+
+        // Act
+        var result = await Sut.OnGetAsync(id);
+
+        // Assert
+        result.Should().BeOfType<NotFoundResult>();
+        MockAccountService.Verify(x => x.GetByIdAsync(id), Times.Once);
+        VerifyAllNoOtherCalls();
     }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/ViewAccountDetailsPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/ViewAccountDetailsPageTests.cs
@@ -150,4 +150,21 @@ public class ViewAccountDetailsPageTests : ManageAccountsPageTestBase<ViewAccoun
         MockAccountService.Verify(x => x.GetByIdAsync(id), Times.Once);
         VerifyAllNoOtherCalls();
     }
+
+    [Fact]
+    public async Task Get_WhenCalledAndNoAccountTypes_ReturnsPageResult()
+    {
+        // Arrange
+        var account = AccountBuilder.WithTypes(null).Build();
+
+        MockAccountService.Setup(x => x.GetByIdAsync(account.Id)).ReturnsAsync(account);
+
+        // Act
+        var result = await Sut.OnGetAsync(account.Id);
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        MockAccountService.Verify(x => x.GetByIdAsync(account.Id), Times.Once);
+        VerifyAllNoOtherCalls();
+    }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/ViewAccountDetailsPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/ViewAccountDetailsPageTests.cs
@@ -99,7 +99,6 @@ public class ViewAccountDetailsPageTests : ManageAccountsPageTestBase<ViewAccoun
     {
         // Arrange
         var account = AccountBuilder.Build();
-        var accountDetails = AccountDetails.FromAccount(account);
 
         MockAccountService.Setup(x => x.GetByIdAsync(account.Id)).ReturnsAsync(account);
 

--- a/apps/user-management/apps/frontend/HttpClients/AuthService/Models/Person.cs
+++ b/apps/user-management/apps/frontend/HttpClients/AuthService/Models/Person.cs
@@ -62,4 +62,6 @@ public class Person
     public string? OtherRouteIntoSocialWork { get; set; }
 
     public int? SocialWorkQualificationEndYear { get; set; }
+
+    public bool HasCompletedLoginAccountLinking { get; set; }
 }

--- a/apps/user-management/apps/frontend/Mappers/AccountMapper.cs
+++ b/apps/user-management/apps/frontend/Mappers/AccountMapper.cs
@@ -40,7 +40,8 @@ public class AccountMapper : IModelMapper<Person, Account>
             HighestQualification = person.HighestQualification,
             SocialWorkQualificationEndYear = person.SocialWorkQualificationEndYear,
             RouteIntoSocialWork = person.RouteIntoSocialWork,
-            OtherRouteIntoSocialWork = person.OtherRouteIntoSocialWork
+            OtherRouteIntoSocialWork = person.OtherRouteIntoSocialWork,
+            HasCompletedLoginAccountLinking = person.HasCompletedLoginAccountLinking
         };
     }
 

--- a/apps/user-management/apps/frontend/Models/Account.cs
+++ b/apps/user-management/apps/frontend/Models/Account.cs
@@ -120,6 +120,8 @@ public record Account
     public bool IsStaff =>
         Types?.Any(t => t is AccountType.Coordinator or AccountType.Assessor) ?? false;
 
+    public bool HasCompletedLoginAccountLinking { get; set; }
+
     public Account() { }
 
     public Account(Account account)
@@ -158,5 +160,6 @@ public record Account
         SocialWorkQualificationEndYear = account.SocialWorkQualificationEndYear;
         RouteIntoSocialWork = account.RouteIntoSocialWork;
         OtherRouteIntoSocialWork = account.OtherRouteIntoSocialWork;
+        HasCompletedLoginAccountLinking = account.HasCompletedLoginAccountLinking;
     }
 }

--- a/apps/user-management/apps/frontend/Models/Account.cs
+++ b/apps/user-management/apps/frontend/Models/Account.cs
@@ -53,7 +53,7 @@ public record Account
     /// Account status
     /// </summary>
     [Display(Name = "Status")]
-    public AccountStatus? Status { get; init; }
+    public AccountStatus? Status { get; set; }
 
     /// <summary>
     /// Account types
@@ -121,8 +121,6 @@ public record Account
         Types?.Any(t => t is AccountType.Coordinator or AccountType.Assessor) ?? false;
 
     public bool HasCompletedLoginAccountLinking { get; set; }
-
-    public Account() { }
 
     public Account(Account account)
     {

--- a/apps/user-management/apps/frontend/Models/RegisterSocialWorker/RegisterSocialWorkerJourneyModel.cs
+++ b/apps/user-management/apps/frontend/Models/RegisterSocialWorker/RegisterSocialWorkerJourneyModel.cs
@@ -48,8 +48,6 @@ public class RegisterSocialWorkerJourneyModel(Account account)
 
     public string? OtherRouteIntoSocialWork { get; set; } = account.OtherRouteIntoSocialWork;
 
-    public AccountStatus? Status { get; set; } = AccountStatus.Active;
-
     public Account ToAccount()
     {
         return new Account(Account)
@@ -74,8 +72,7 @@ public class RegisterSocialWorkerJourneyModel(Account account)
             HighestQualification = HighestQualification,
             SocialWorkQualificationEndYear = SocialWorkQualificationEndYear,
             RouteIntoSocialWork = RouteIntoSocialWork,
-            OtherRouteIntoSocialWork = OtherRouteIntoSocialWork,
-            Status = Status
+            OtherRouteIntoSocialWork = OtherRouteIntoSocialWork
         };
     }
 }

--- a/apps/user-management/apps/frontend/Models/RegisterSocialWorker/RegisterSocialWorkerJourneyModel.cs
+++ b/apps/user-management/apps/frontend/Models/RegisterSocialWorker/RegisterSocialWorkerJourneyModel.cs
@@ -48,6 +48,8 @@ public class RegisterSocialWorkerJourneyModel(Account account)
 
     public string? OtherRouteIntoSocialWork { get; set; } = account.OtherRouteIntoSocialWork;
 
+    public AccountStatus? Status { get; set; } = AccountStatus.Active;
+
     public Account ToAccount()
     {
         return new Account(Account)
@@ -72,7 +74,8 @@ public class RegisterSocialWorkerJourneyModel(Account account)
             HighestQualification = HighestQualification,
             SocialWorkQualificationEndYear = SocialWorkQualificationEndYear,
             RouteIntoSocialWork = RouteIntoSocialWork,
-            OtherRouteIntoSocialWork = OtherRouteIntoSocialWork
+            OtherRouteIntoSocialWork = OtherRouteIntoSocialWork,
+            Status = Status
         };
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/ViewAccountDetails.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/ViewAccountDetails.cshtml
@@ -1,5 +1,6 @@
 @page "{id:Guid}"
 @using System.Globalization
+@using Dfe.Sww.Ecf.Frontend.Models
 @model ViewAccountDetails
 
 @{
@@ -16,94 +17,99 @@
         <div class="govuk-!-margin-bottom-6">
             <account-status status="@Model.Account.Status"/>
         </div>
-
-        <govuk-summary-list>
-            <govuk-summary-list-row>
-                <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.Account.Types)</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>
-                    <account-types types="Model.Account.Types"/>
-                </govuk-summary-list-row-value>
-                @if (!Model.IsSocialWorker)
+        <form method="post">
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>@Html.DisplayNameFor(model => model.Account.Types)</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>
+                        <account-types types="Model.Account.Types"/>
+                    </govuk-summary-list-row-value>
+                    @if (!Model.IsSocialWorker)
+                    {
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="#" visually-hidden-text="account details">Change
+                            </govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    }
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>First name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Html.DisplayFor(model => model.Account.FirstName)</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
+                                                       visually-hidden-text="account details">Change
+                        </govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                @if (!string.IsNullOrEmpty(Model.Account.MiddleNames))
                 {
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="#" visually-hidden-text="account details">Change
-                        </govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Middle names</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@Model.Account.MiddleNames</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
+                                                           visually-hidden-text="account details">Change
+                            </govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    </govuk-summary-list-row>
                 }
-            </govuk-summary-list-row>
-            <govuk-summary-list-row>
-                <govuk-summary-list-row-key>First name</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>@Html.DisplayFor(model => model.Account.FirstName)</govuk-summary-list-row-value>
-                <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
-                                                   visually-hidden-text="account details">Change
-                    </govuk-summary-list-row-action>
-                </govuk-summary-list-row-actions>
-            </govuk-summary-list-row>
-            @if (!string.IsNullOrEmpty(Model.Account.MiddleNames))
-            {
                 <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Middle names</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.Account.MiddleNames</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-key>Last name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.Account.LastName</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
                         <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
                                                        visually-hidden-text="account details">Change
                         </govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
-            }
-            <govuk-summary-list-row>
-                <govuk-summary-list-row-key>Last name</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>@Model.Account.LastName</govuk-summary-list-row-value>
-                <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
-                                                   visually-hidden-text="account details">Change
-                    </govuk-summary-list-row-action>
-                </govuk-summary-list-row-actions>
-            </govuk-summary-list-row>
-            <govuk-summary-list-row>
-                <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>@Model.Account.Email</govuk-summary-list-row-value>
-                <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
-                                                   visually-hidden-text="account details">Change
-                    </govuk-summary-list-row-action>
-                </govuk-summary-list-row-actions>
-            </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.Account.Email</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
+                                                       visually-hidden-text="account details">Change
+                        </govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
 
-            @if (Model.IsSocialWorker || Model.IsAssessor)
+                @if (Model.IsSocialWorker || Model.IsAssessor)
+                {
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>SWE registration number</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@Model.Account.SocialWorkEnglandNumber</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
+                                                           visually-hidden-text="account details">Change
+                            </govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    </govuk-summary-list-row>
+                }
+                @if (Model.IsSocialWorker)
+                {
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Programme start date</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@Model.Account.ProgrammeStartDate?.ToString("MMMM yyyy", CultureInfo.InvariantCulture)</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
+                                                           visually-hidden-text="account details">Change
+                            </govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    </govuk-summary-list-row>
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Expected programme end date</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@Model.Account.ProgrammeEndDate?.ToString("MMMM yyyy", CultureInfo.InvariantCulture)</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
+                                                           visually-hidden-text="account details">Change
+                            </govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    </govuk-summary-list-row>
+                }
+            </govuk-summary-list>
+            @if (!Model.HasCompletedLoginAccountLinking && Model.Account.Status != AccountStatus.Inactive)
             {
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>SWE registration number</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.Account.SocialWorkEnglandNumber</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
-                                                       visually-hidden-text="account details">Change
-                        </govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
-                </govuk-summary-list-row>
+                <govuk-button type="submit" class="govuk-button--secondary">Resend invitation to register</govuk-button>
             }
-            @if (Model.IsSocialWorker)
-            {
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Programme start date</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.Account.ProgrammeStartDate?.ToString("MMMM yyyy", CultureInfo.InvariantCulture)</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
-                                                       visually-hidden-text="account details">Change
-                        </govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Expected programme end date</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.Account.ProgrammeEndDate?.ToString("MMMM yyyy", CultureInfo.InvariantCulture)</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.EditAccountDetails(Model.Account.Id)"
-                                                       visually-hidden-text="account details">Change
-                        </govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
-                </govuk-summary-list-row>
-            }
-        </govuk-summary-list>
+        </form>
     </div>
 </div>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/ViewAccountDetails.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/ViewAccountDetails.cshtml.cs
@@ -3,12 +3,17 @@ using Dfe.Sww.Ecf.Frontend.Models;
 using Dfe.Sww.Ecf.Frontend.Pages.Shared;
 using Dfe.Sww.Ecf.Frontend.Routing;
 using Dfe.Sww.Ecf.Frontend.Services.Interfaces;
+using Dfe.Sww.Ecf.Frontend.Services.Journeys.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
 
 [AuthorizeRoles(RoleType.Coordinator)]
-public class ViewAccountDetails(IAccountService accountService, EcfLinkGenerator linkGenerator)
+public class ViewAccountDetails(
+    IAccountService accountService,
+    EcfLinkGenerator linkGenerator,
+    ICreateAccountJourneyService createAccountJourneyService
+)
     : BasePageModel
 {
     public Account Account { get; set; } = default!;
@@ -16,6 +21,8 @@ public class ViewAccountDetails(IAccountService accountService, EcfLinkGenerator
     public bool IsSocialWorker { get; set; }
 
     public bool IsAssessor { get; set; }
+
+    public bool HasCompletedLoginAccountLinking { get; set; }
 
     public async Task<IActionResult> OnGetAsync(Guid id)
     {
@@ -29,7 +36,14 @@ public class ViewAccountDetails(IAccountService accountService, EcfLinkGenerator
 
         IsSocialWorker = Account.Types.Contains(AccountType.EarlyCareerSocialWorker);
         IsAssessor = Account.Types.Contains(AccountType.Assessor);
+        HasCompletedLoginAccountLinking = Account.HasCompletedLoginAccountLinking;
 
         return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        await createAccountJourneyService.SendInvitationEmailAsync(Account);
+        return Redirect(linkGenerator.ManageAccounts());
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/ViewAccountDetails.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/ViewAccountDetails.cshtml.cs
@@ -16,7 +16,6 @@ public class ViewAccountDetails(
 )
     : BasePageModel
 {
-    public Guid Id { get; set; }
     public Account Account { get; set; } = default!;
 
     public bool IsSocialWorker { get; set; }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/ViewAccountDetails.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/ViewAccountDetails.cshtml.cs
@@ -16,6 +16,7 @@ public class ViewAccountDetails(
 )
     : BasePageModel
 {
+    public Guid Id { get; set; }
     public Account Account { get; set; } = default!;
 
     public bool IsSocialWorker { get; set; }
@@ -41,9 +42,11 @@ public class ViewAccountDetails(
         return Page();
     }
 
-    public async Task<IActionResult> OnPostAsync()
+    public async Task<IActionResult> OnPostAsync(Guid id)
     {
-        await createAccountJourneyService.SendInvitationEmailAsync(Account);
+        var account = await accountService.GetByIdAsync(id);
+        if (account is null) return NotFound();
+        await createAccountJourneyService.SendInvitationEmailAsync(account);
         return Redirect(linkGenerator.ManageAccounts());
     }
 }

--- a/apps/user-management/apps/frontend/Services/Journeys/CreateAccountJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/CreateAccountJourneyService.cs
@@ -246,7 +246,7 @@ public class CreateAccountJourneyService(
         return createAccountJourneyModel.SocialWorkerDetails;
     }
 
-    private async Task SendInvitationEmailAsync(Account account)
+    public async Task SendInvitationEmailAsync(Account account)
     {
         var accountTypes = GetAccountTypes();
 

--- a/apps/user-management/apps/frontend/Services/Journeys/CreateAccountJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/CreateAccountJourneyService.cs
@@ -248,7 +248,7 @@ public class CreateAccountJourneyService(
 
     public async Task SendInvitationEmailAsync(Account account)
     {
-        var accountTypes = GetAccountTypes();
+        var accountTypes = account.Types;
 
         if (
             accountTypes is null

--- a/apps/user-management/apps/frontend/Services/Journeys/Interfaces/ICreateAccountJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/Interfaces/ICreateAccountJourneyService.cs
@@ -58,4 +58,6 @@ public interface ICreateAccountJourneyService
     AccountLabels? GetAccountLabels();
 
     AccountChangeLinks GetAccountChangeLinks();
+
+    Task SendInvitationEmailAsync(Account account);
 }

--- a/apps/user-management/apps/frontend/Services/Journeys/RegisterSocialWorkerJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/RegisterSocialWorkerJourneyService.cs
@@ -239,7 +239,7 @@ public class RegisterSocialWorkerJourneyService : IRegisterSocialWorkerJourneySe
         updatedAccount.SocialWorkQualificationEndYear = registerSocialWorkerJourneyModel.SocialWorkQualificationEndYear;
         updatedAccount.RouteIntoSocialWork = registerSocialWorkerJourneyModel.RouteIntoSocialWork;
         updatedAccount.OtherRouteIntoSocialWork = registerSocialWorkerJourneyModel.OtherRouteIntoSocialWork;
-        //updatedAccount.Status = registerSocialWorkerJourneyModel.Status;
+        updatedAccount.Status = AccountStatus.Active;
 
         await _accountService.UpdateAsync(updatedAccount);
 

--- a/apps/user-management/apps/frontend/Services/Journeys/RegisterSocialWorkerJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/RegisterSocialWorkerJourneyService.cs
@@ -239,6 +239,7 @@ public class RegisterSocialWorkerJourneyService : IRegisterSocialWorkerJourneySe
         updatedAccount.SocialWorkQualificationEndYear = registerSocialWorkerJourneyModel.SocialWorkQualificationEndYear;
         updatedAccount.RouteIntoSocialWork = registerSocialWorkerJourneyModel.RouteIntoSocialWork;
         updatedAccount.OtherRouteIntoSocialWork = registerSocialWorkerJourneyModel.OtherRouteIntoSocialWork;
+        //updatedAccount.Status = registerSocialWorkerJourneyModel.Status;
 
         await _accountService.UpdateAsync(updatedAccount);
 

--- a/apps/user-management/apps/frontend/appsettings.Development.json
+++ b/apps/user-management/apps/frontend/appsettings.Development.json
@@ -26,7 +26,7 @@
         }
     },
     "NotificationClientOptions": {
-        "BaseUrl": "http://localhost:7071",
+        "BaseUrl": "http://localhost:7124",
         "Routes": {
             "Notification": {
                 "SendEmail": "/api/Notification"


### PR DESCRIPTION
PR for [SWIP-629](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-629) including:
- changes to the auth service to return a true/false flag with the details of a given person; this captures whether they have ever logged into our service via OneLogin
- frontend chages to use this "has ever logged in" flag to display the "Resend invitation email" button on the view user details page, only for user that have never logged in
- supressing this button from being displayed for users that have the status "Inactive"
- as part of the ECSW registration journey completion, set the user's status to "Active"
- unit tests

[SWIP-629]: https://dfedigital.atlassian.net/browse/SWIP-629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ