### PR TITLE
SWIP-660 Set error summary to prepend to form

### DIFF
--- a/apps/user-management/apps/frontend/Program.cs
+++ b/apps/user-management/apps/frontend/Program.cs
@@ -34,6 +34,7 @@ builder.Services.AddGovUkFrontend(options =>
 {
     options.RegisterDateInputModelConverter(typeof(LocalDate), new LocalDateDateInputModelConverter());
     options.RegisterDateInputModelConverter(typeof(YearMonth), new YearMonthDateInputModelConverter());
+    options.ErrorSummaryGeneration = ErrorSummaryGenerationOptions.PrependToFormElements;
 });
 builder.Services.AddCsp(nonceByteAmount: 32);
 builder


### PR DESCRIPTION
Changes to settings for govuk frontend .NET package to inject the error summary at the top of forms instead of the default, which is at the top of main. More info on the decision in [SWIP-660](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-660).

[SWIP-660]: https://dfedigital.atlassian.net/browse/SWIP-660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ