### PR TITLE
SWIP-653 Add SWE number field for assessor details capture

### DIFF
--- a/apps/user-management/apps/frontend.Test/UnitTests/Helpers/Builders/AccountBuilder.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Helpers/Builders/AccountBuilder.cs
@@ -22,7 +22,7 @@ public class AccountBuilder
         _faker.RuleFor(
             a => a.SocialWorkEnglandNumber,
             (f, current) =>
-                current.Types?.Contains(AccountType.EarlyCareerSocialWorker) == true
+                current.Types?.Contains(AccountType.EarlyCareerSocialWorker) == true || current.Types?.Contains(AccountType.Assessor) == true
                     ? f.Random.Number(1, 1000).ToString()
                     : null
         );
@@ -83,6 +83,7 @@ public class AccountBuilder
         _faker.RuleFor(a => a.SocialWorkQualificationEndYear, _ => null);
         _faker.RuleFor(a => a.RouteIntoSocialWork, _ => null);
         _faker.RuleFor(a => a.OtherRouteIntoSocialWork, _ => null);
+        _faker.RuleFor(a => a.Types, _ => null);
         return this;
     }
 
@@ -133,7 +134,7 @@ public class AccountBuilder
         _faker.RuleFor(
             x => x.SocialWorkEnglandNumber,
             (_, current) =>
-                current.Types?.Contains(AccountType.EarlyCareerSocialWorker) == true
+                current.Types?.Contains(AccountType.EarlyCareerSocialWorker) == true || current.Types?.Contains(AccountType.Assessor) == true
                     ? socialWorkEnglandNumber
                     : null
         );

--- a/apps/user-management/apps/frontend.Test/UnitTests/Helpers/Fakers/AccountDetailsFaker.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Helpers/Fakers/AccountDetailsFaker.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Bogus;
 using Dfe.Sww.Ecf.Frontend.Models;
 
@@ -39,11 +40,15 @@ public static class AccountDetailsFakerExtensions
             .Generate();
     }
 
-    public static AccountDetails GenerateWithSweId(
+    public static AccountDetails GenerateWithSweIdAndRelevantAccountType(
         this AccountDetailsFaker accountDetailsFaker,
-        string? sweId
+        string? sweId,
+        IList<AccountType> accountTypes
     )
     {
-        return accountDetailsFaker.RuleFor(a => a.SocialWorkEnglandNumber, _ => sweId).Generate();
+        return accountDetailsFaker
+            .RuleFor(a => a.SocialWorkEnglandNumber, _ => sweId)
+            .RuleFor(a => a.Types, _ => accountTypes)
+            .Generate();
     }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Validators/AccountDetailsValidatorTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Validators/AccountDetailsValidatorTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Dfe.Sww.Ecf.Frontend.Models;
 using Dfe.Sww.Ecf.Frontend.Test.UnitTests.Helpers.Fakers;
 using Dfe.Sww.Ecf.Frontend.Validation;
@@ -29,12 +30,12 @@ public class AccountDetailsValidatorTests()
     [InlineData("")]
     [InlineData(null)]
     [InlineData("     ")]
-    public void WhenAnyInputNotSupplied_WhenIsNotStaff_HasValidationErrors(string? value)
+    public void WhenAnyInputNotSupplied_WhenIsSocialWorkerOrAssessor_HasValidationErrors(string? value)
     {
         // Arrange
         var account = new AccountDetails
         {
-            IsStaff = false,
+            Types = ImmutableList.Create(AccountType.EarlyCareerSocialWorker),
             FirstName = value,
             LastName = value,
             Email = value,
@@ -63,12 +64,12 @@ public class AccountDetailsValidatorTests()
     [InlineData("")]
     [InlineData(null)]
     [InlineData("     ")]
-    public void WhenAnyInputNotSupplied_WhenIsStaff_HasValidationErrors(string? value)
+    public void WhenAnyInputNotSupplied_WhenIsCoordinator_HasValidationErrors(string? value)
     {
         // Arrange
         var account = new AccountDetails
         {
-            IsStaff = true,
+            Types = ImmutableList.Create(AccountType.Coordinator),
             FirstName = value,
             LastName = value,
             Email = value
@@ -98,7 +99,7 @@ public class AccountDetailsValidatorTests()
     public void WhenSocialWorkerNumberIsInvalid_HasValidationErrors(string? sweId)
     {
         // Arrange
-        var account = Faker.GenerateWithSweId(sweId);
+        var account = Faker.GenerateWithSweIdAndRelevantAccountType(sweId,ImmutableList.Create(AccountType.EarlyCareerSocialWorker));
 
         // Act
         var result = Sut.TestValidate(account);

--- a/apps/user-management/apps/frontend/Models/AccountDetails.cs
+++ b/apps/user-management/apps/frontend/Models/AccountDetails.cs
@@ -77,6 +77,8 @@ public class AccountDetails
 
     public int? SocialWorkQualificationEndYear { get; set; }
 
+    public IList<AccountType>? Types { get; init; }
+
     public static AccountDetails FromAccount(Account account)
     {
         return new AccountDetails
@@ -111,7 +113,8 @@ public class AccountDetails
             HighestQualification = account.HighestQualification,
             SocialWorkQualificationEndYear = account.SocialWorkQualificationEndYear,
             RouteIntoSocialWork = account.RouteIntoSocialWork,
-            OtherRouteIntoSocialWork = account.OtherRouteIntoSocialWork
+            OtherRouteIntoSocialWork = account.OtherRouteIntoSocialWork,
+            Types = account.Types
         };
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/AddAccountDetails.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/AddAccountDetails.cshtml
@@ -1,4 +1,5 @@
 ﻿@page
+@using Dfe.Sww.Ecf.Frontend.Models
 @model Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts.AddAccountDetails
 
 @{
@@ -31,7 +32,7 @@
                     <govuk-input-error-message/>
                 </govuk-input>
 
-                @if (!Model.IsStaff)
+                @if (Model.AccountTypes.Contains(AccountType.Assessor) || Model.AccountTypes.Contains(AccountType.EarlyCareerSocialWorker))
                 {
                     <govuk-input for="SocialWorkEnglandNumber" spellcheck="false" input-class="govuk-input--width-10">
                         <govuk-input-label>Social Work England registration number</govuk-input-label>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/AddAccountDetails.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/AddAccountDetails.cshtml.cs
@@ -58,6 +58,8 @@ public class AddAccountDetails(
 
     public bool IsStaff = createAccountJourneyService.GetIsStaff() ?? false;
 
+    public IList<AccountType> AccountTypes { get; set; } = createAccountJourneyService.GetAccountTypes() ?? new List<AccountType>();
+
     private void SetBackLinkPath(bool fromConfirmPage = false)
     {
         BackLinkPath ??= fromConfirmPage
@@ -98,6 +100,7 @@ public class AddAccountDetails(
             Email = Email,
             SocialWorkEnglandNumber = SocialWorkEnglandNumber,
             IsStaff = IsStaff,
+            Types = AccountTypes
         };
         var result = await validator.ValidateAsync(accountDetails);
         if (!result.IsValid)

--- a/apps/user-management/apps/frontend/Validation/AccountDetailsValidator.cs
+++ b/apps/user-management/apps/frontend/Validation/AccountDetailsValidator.cs
@@ -17,7 +17,7 @@ public class AccountDetailsValidator : AbstractValidator<AccountDetails>
         RuleFor(y => y.LastName).LastNameValidation();
         RuleFor(y => y.Email).EmailValidation();
         When(
-            x => x.IsStaff == false,
+            x => x.Types?.Contains(AccountType.Assessor) == true || x.Types?.Contains(AccountType.EarlyCareerSocialWorker) == true,
             () => { RuleFor(y => y.SocialWorkEnglandNumber).SocialWorkEnglandNumberValidation(); }
         );
     }


### PR DESCRIPTION
Changes as part of [SWIP-653](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-653):
- logic changes to include the SWE number field when capturing the details of a new assessor
- unit test changes
- validator logic changes

[SWIP-653]: https://dfedigital.atlassian.net/browse/SWIP-653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ