### PR TITLE
SWIP-694 change staff account type during registration

### DIFF
--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityAgencyWorkerPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityAgencyWorkerPageTests.cs
@@ -81,17 +81,11 @@ public class EligibilityAgencyWorkerPageTests : ManageAccountsPageTestBase<Eligi
         VerifyAllNoOtherCalls();
     }
 
-    [Theory]
-    [InlineData(true, "/manage-accounts/eligibility-funding-not-available?handler=Change")]
-    [InlineData(false, "/manage-accounts/eligibility-funding-not-available")]
-    public async Task OnPostAsync_WhenCalledWithIsAgencyWorkerTrue_RedirectsToEligibilityFundingNotAvailable(
-        bool fromChangeLink,
-        string redirectPath
-    )
+    [Fact]
+    public async Task OnPostAsync_WhenCalledWithIsAgencyWorkerTrue_RedirectsToEligibilityFundingNotAvailable()
     {
         // Arrange
         Sut.IsAgencyWorker = true;
-        Sut.FromChangeLink = fromChangeLink;
 
         // Act
         var result = await Sut.OnPostAsync();
@@ -100,51 +94,19 @@ public class EligibilityAgencyWorkerPageTests : ManageAccountsPageTestBase<Eligi
         result.Should().BeOfType<RedirectResult>();
         var redirectResult = result as RedirectResult;
         redirectResult.Should().NotBeNull();
-        redirectResult!.Url.Should().Be(redirectPath);
+        redirectResult!.Url.Should().Be("/manage-accounts/eligibility-funding-not-available");
 
         MockCreateAccountJourneyService.Verify(x => x.SetIsAgencyWorker(true), Times.Once);
         MockCreateAccountJourneyService.Verify(x => x.SetIsRecentlyQualified(null), Times.Once);
-        MockCreateAccountJourneyService.Verify(x => x.GetIsAgencyWorker(), Times.Once);
 
         VerifyAllNoOtherCalls();
     }
 
     [Fact]
-    public async Task OnPostAsync_WhenCalledWithIsAgencyWorkerTrueAndPreviousValueSelectedTrue_RedirectsToConfirmAccountDetails()
-    {
-        // Arrange
-        Sut.IsAgencyWorker = true;
-        Sut.FromChangeLink = true;
-        MockCreateAccountJourneyService.Setup(x => x.GetIsAgencyWorker())
-            .Returns(true);
-
-        // Act
-        var result = await Sut.OnPostAsync();
-
-        // Assert
-        result.Should().BeOfType<RedirectResult>();
-        var redirectResult = result as RedirectResult;
-        redirectResult.Should().NotBeNull();
-        redirectResult!.Url.Should().Be("/manage-accounts/confirm-account-details");
-
-        MockCreateAccountJourneyService.Verify(x => x.SetIsAgencyWorker(true), Times.Once);
-        MockCreateAccountJourneyService.Verify(x => x.SetIsRecentlyQualified(null), Times.Once);
-        MockCreateAccountJourneyService.Verify(x => x.GetIsAgencyWorker(), Times.Once);
-
-        VerifyAllNoOtherCalls();
-    }
-
-    [Theory]
-    [InlineData(true, "/manage-accounts/eligibility-qualification?handler=Change")]
-    [InlineData(false, "/manage-accounts/eligibility-qualification")]
-    public async Task OnPostAsync_WhenCalledWithIsAgencyWorkerFalse_RedirectsToCorrectEligibilityQualificationPage(
-        bool fromChangeLink,
-        string redirectPath
-    )
+    public async Task OnPostAsync_WhenCalledWithIsAgencyWorkerFalse_RedirectsToCorrectEligibilityQualificationPage()
     {
         // Arrange
         Sut.IsAgencyWorker = false;
-        Sut.FromChangeLink = fromChangeLink;
 
         // Act
         var result = await Sut.OnPostAsync();
@@ -153,10 +115,9 @@ public class EligibilityAgencyWorkerPageTests : ManageAccountsPageTestBase<Eligi
         result.Should().BeOfType<RedirectResult>();
         var redirectResult = result as RedirectResult;
         redirectResult.Should().NotBeNull();
-        redirectResult!.Url.Should().Be(redirectPath);
+        redirectResult!.Url.Should().Be("/manage-accounts/eligibility-qualification");
 
         MockCreateAccountJourneyService.Verify(x => x.SetIsAgencyWorker(false), Times.Once);
-        MockCreateAccountJourneyService.Verify(x => x.GetIsAgencyWorker(), Times.Once);
 
         VerifyAllNoOtherCalls();
     }
@@ -174,15 +135,5 @@ public class EligibilityAgencyWorkerPageTests : ManageAccountsPageTestBase<Eligi
         Sut.FromChangeLink.Should().BeTrue();
         MockCreateAccountJourneyService.Verify(x => x.GetIsAgencyWorker(), Times.Once);
         VerifyAllNoOtherCalls();
-    }
-
-    [Fact]
-    public async Task OnPostChangeAsync_WhenCalled_HasFromChangeLinkTrue()
-    {
-        // Act
-        _ = await Sut.OnPostChangeAsync();
-
-        // Assert
-        Sut.FromChangeLink.Should().BeTrue();
     }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityFundingNotAvailablePageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityFundingNotAvailablePageTests.cs
@@ -1,3 +1,4 @@
+using Dfe.Sww.Ecf.Frontend.Models;
 using Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
 using Dfe.Sww.Ecf.Frontend.Test.UnitTests.Helpers;
 using FluentAssertions;
@@ -22,7 +23,7 @@ public class EligibilityFundingNotAvailablePageTests : ManageAccountsPageTestBas
     [Theory]
     [InlineData(true, "/manage-accounts/eligibility-agency-worker")]
     [InlineData(false, "/manage-accounts/eligibility-qualification")]
-    public void OnGet_WhenCalled_LoadsTheView(bool isAgencyWorker, string expectedBackLink)
+    public void OnGet_WhenCalled_LoadsTheViewWithCorrectBackLinks(bool isAgencyWorker, string expectedBackLink)
     {
         MockCreateAccountJourneyService.Setup(x => x.GetIsAgencyWorker()).Returns(isAgencyWorker);
 
@@ -32,26 +33,74 @@ public class EligibilityFundingNotAvailablePageTests : ManageAccountsPageTestBas
         // Assert
         result.Should().BeOfType<PageResult>();
         Sut.BackLinkPath.Should().Be(expectedBackLink);
-        Sut.NextPagePath.Should().Be("/manage-accounts/add-account-details");
-        Sut.FromChangeLink.Should().BeFalse();
 
         MockCreateAccountJourneyService.Verify(x => x.GetIsAgencyWorker(), Times.Once);
+        MockCreateAccountJourneyService.Verify(x => x.GetAccountDetails(), Times.Once);
         VerifyAllNoOtherCalls();
     }
 
     [Fact]
-    public void OnGetChange_WhenCalled_LoadsTheViewWithNextPageConfirmAccountDetails()
+    public void OnGet_WhenCalledAndSocialEnglandNumberNeedsCapturing_LoadsTheViewWithContinueToAccountDetailsPage()
     {
+        // Arrange
+        var account = AccountBuilder.WithSocialWorkEnglandNumber(null).Build();
+        var accountDetails = AccountDetails.FromAccount(account);
+        MockCreateAccountJourneyService.Setup(x => x.GetAccountDetails()).Returns(accountDetails);
+
         // Act
-        var result = Sut.OnGetChange();
+        var result = Sut.OnGet();
 
         // Assert
         result.Should().BeOfType<PageResult>();
-
-        Sut.FromChangeLink.Should().BeTrue();
-        Sut.NextPagePath.Should().Be("/manage-accounts/confirm-account-details");
-
+        Sut.NextPagePath.Should().Be("/manage-accounts/add-account-details");
         MockCreateAccountJourneyService.Verify(x => x.GetIsAgencyWorker(), Times.Once);
+        MockCreateAccountJourneyService.Verify(x => x.GetAccountDetails(), Times.Once);
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public void OnGet_WhenCalledAndProgrammeDatesNeedCapturing_LoadsTheViewWithContinueToProgrammeDatesPage()
+    {
+        //Arrange
+        var account = AccountBuilder
+            .WithTypes([AccountType.EarlyCareerSocialWorker])
+            .WithSocialWorkEnglandNumber("12343").Build();
+        var accountDetails = AccountDetails.FromAccount(account);
+        MockCreateAccountJourneyService.Setup(x => x.GetAccountDetails()).Returns(accountDetails);
+        MockCreateAccountJourneyService.Setup(x => x.GetProgrammeStartDate()).Returns((DateOnly?)null);
+
+        // Act
+        var result = Sut.OnGet();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        Sut.NextPagePath.Should().Be("/manage-accounts/social-worker-programme-dates");
+        MockCreateAccountJourneyService.Verify(x => x.GetIsAgencyWorker(), Times.Once);
+        MockCreateAccountJourneyService.Verify(x => x.GetAccountDetails(), Times.Once);
+        MockCreateAccountJourneyService.Verify(x => x.GetProgrammeStartDate(), Times.Once);
+        VerifyAllNoOtherCalls();
+    }
+
+    [Fact]
+    public void OnGet_WhenCalledAndAllDetailsNeededAreAlreadyCaptured_LoadsTheViewWithContinueToConfirmDetailsPage()
+    {
+        //Arrange
+        var account = AccountBuilder
+            .WithTypes([AccountType.EarlyCareerSocialWorker])
+            .WithSocialWorkEnglandNumber("12343").Build();
+        var accountDetails = AccountDetails.FromAccount(account);
+        MockCreateAccountJourneyService.Setup(x => x.GetAccountDetails()).Returns(accountDetails);
+        MockCreateAccountJourneyService.Setup(x => x.GetProgrammeStartDate()).Returns(DateOnly.FromDateTime(DateTime.Now));
+
+        // Act
+        var result = Sut.OnGet();
+
+        // Assert
+        result.Should().BeOfType<PageResult>();
+        Sut.NextPagePath.Should().Be("/manage-accounts/confirm-account-details");
+        MockCreateAccountJourneyService.Verify(x => x.GetIsAgencyWorker(), Times.Once);
+        MockCreateAccountJourneyService.Verify(x => x.GetAccountDetails(), Times.Once);
+        MockCreateAccountJourneyService.Verify(x => x.GetProgrammeStartDate(), Times.Once);
         VerifyAllNoOtherCalls();
     }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityQualificationPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EligibilityQualificationPageTests.cs
@@ -123,30 +123,6 @@ public class EligibilityQualificationPageTests : ManageAccountsPageTestBase<Elig
         VerifyAllNoOtherCalls();
     }
 
-    [Theory]
-    [InlineData(true, "/manage-accounts/eligibility-funding-available?handler=Change")]
-    [InlineData(false, "/manage-accounts/eligibility-funding-not-available?handler=Change")]
-    public async Task
-        OnPostAsync_WhenCalledFromChangeLink_RedirectsToRelevantPage(bool isRecentlyQualified, string redirectPath)
-    {
-        // Arrange
-        Sut.FromChangeLink = true;
-        Sut.IsRecentlyQualified = isRecentlyQualified;
-
-        // Act
-        var result = await Sut.OnPostAsync();
-
-        // Assert
-        result.Should().BeOfType<RedirectResult>();
-        var redirectResult = result as RedirectResult;
-        redirectResult.Should().NotBeNull();
-        redirectResult!.Url.Should().Be(redirectPath);
-
-        MockCreateAccountJourneyService.Verify(x => x.SetIsRecentlyQualified(isRecentlyQualified), Times.Once);
-
-        VerifyAllNoOtherCalls();
-    }
-
     [Fact]
     public void OnGetChange_WhenCalled_LoadsTheView()
     {
@@ -160,15 +136,5 @@ public class EligibilityQualificationPageTests : ManageAccountsPageTestBase<Elig
         Sut.FromChangeLink.Should().BeTrue();
         MockCreateAccountJourneyService.Verify(x => x.GetIsRecentlyQualified(), Times.Once);
         VerifyAllNoOtherCalls();
-    }
-
-    [Fact]
-    public async Task OnPostChangeAsync_WhenCalled_HasFromChangeLinkTrue()
-    {
-        // Act
-        _ = await Sut.OnPostChangeAsync();
-
-        // Assert
-        Sut.FromChangeLink.Should().BeTrue();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityAgencyWorker.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityAgencyWorker.cshtml.cs
@@ -38,37 +38,20 @@ public class EligibilityAgencyWorker(
             return Page();
         }
 
-        var previousIsAgencyWorkerValue = createAccountJourneyService.GetIsAgencyWorker();
         createAccountJourneyService.SetIsAgencyWorker(IsAgencyWorker);
 
         if (IsAgencyWorker is true)
         {
             createAccountJourneyService.SetIsRecentlyQualified(null);
-            if (FromChangeLink)
-            {
-                if (previousIsAgencyWorkerValue == true)
-                {
-                    return Redirect(linkGenerator.ConfirmAccountDetails());
-                }
-                return Redirect(linkGenerator.EligibilityFundingNotAvailableChange());
-            }
             return Redirect(linkGenerator.EligibilityFundingNotAvailable());
         }
 
-        return Redirect(FromChangeLink
-            ? linkGenerator.EligibilityQualificationChange()
-            : linkGenerator.EligibilityQualification());
+        return Redirect(linkGenerator.EligibilityQualification());
     }
 
     public PageResult OnGetChange()
     {
         FromChangeLink = true;
         return OnGet();
-    }
-
-    public async Task<IActionResult> OnPostChangeAsync()
-    {
-        FromChangeLink = true;
-        return await OnPostAsync();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingAvailable.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingAvailable.cshtml.cs
@@ -2,6 +2,7 @@ using Dfe.Sww.Ecf.Frontend.Authorisation;
 using Dfe.Sww.Ecf.Frontend.Pages.Shared;
 using Dfe.Sww.Ecf.Frontend.Routing;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Dfe.Sww.Ecf.Frontend.Services.Journeys.Interfaces;
 
 namespace Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
 
@@ -9,13 +10,17 @@ namespace Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
 /// Eligibility Funding Available View Model
 /// </summary>
 [AuthorizeRoles(RoleType.Coordinator)]
-public class EligibilityFundingAvailable(EcfLinkGenerator linkGenerator) : BasePageModel
+public class EligibilityFundingAvailable(
+    EcfLinkGenerator linkGenerator,
+    ICreateAccountJourneyService createAccountJourneyService
+    ) : BasePageModel
 {
     public string? NextPagePath { get; set; }
     public PageResult OnGet()
     {
         BackLinkPath = linkGenerator.EligibilityQualification();
-        NextPagePath = FromChangeLink ? linkGenerator.ConfirmAccountDetails() : linkGenerator.AddAccountDetails();
+        var accountDetails = createAccountJourneyService.GetAccountDetails();
+        NextPagePath = FromChangeLink && accountDetails?.SocialWorkEnglandNumber is not null ? linkGenerator.ConfirmAccountDetails() : linkGenerator.AddAccountDetails();
         return Page();
     }
 

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingAvailable.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingAvailable.cshtml.cs
@@ -13,20 +13,27 @@ namespace Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts;
 public class EligibilityFundingAvailable(
     EcfLinkGenerator linkGenerator,
     ICreateAccountJourneyService createAccountJourneyService
-    ) : BasePageModel
+) : BasePageModel
 {
     public string? NextPagePath { get; set; }
+
     public PageResult OnGet()
     {
         BackLinkPath = linkGenerator.EligibilityQualification();
         var accountDetails = createAccountJourneyService.GetAccountDetails();
-        NextPagePath = FromChangeLink && accountDetails?.SocialWorkEnglandNumber is not null ? linkGenerator.ConfirmAccountDetails() : linkGenerator.AddAccountDetails();
-        return Page();
-    }
+        if (accountDetails?.SocialWorkEnglandNumber is null)
+        {
+            NextPagePath = linkGenerator.AddAccountDetails();
+        }
+        else if (createAccountJourneyService.GetProgrammeStartDate() is null)
+        {
+            NextPagePath = linkGenerator.SocialWorkerProgrammeDates();
+        }
+        else
+        {
+            NextPagePath = linkGenerator.ConfirmAccountDetails();
+        }
 
-    public PageResult OnGetChange()
-    {
-        FromChangeLink = true;
-        return OnGet();
+        return Page();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingNotAvailable.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingNotAvailable.cshtml.cs
@@ -15,19 +15,26 @@ public class EligibilityFundingNotAvailable(
     EcfLinkGenerator linkGenerator) : BasePageModel
 {
     public string? NextPagePath { get; set; }
+
     public PageResult OnGet()
     {
         BackLinkPath = createAccountJourneyService.GetIsAgencyWorker() == true
             ? linkGenerator.EligibilityAgencyWorker()
             : linkGenerator.EligibilityQualification();
         var accountDetails = createAccountJourneyService.GetAccountDetails();
-        NextPagePath = FromChangeLink && accountDetails?.SocialWorkEnglandNumber is not null ? linkGenerator.ConfirmAccountDetails() : linkGenerator.AddAccountDetails();
-        return Page();
-    }
+        if (accountDetails?.SocialWorkEnglandNumber is null)
+        {
+            NextPagePath = linkGenerator.AddAccountDetails();
+        }
+        else if (createAccountJourneyService.GetProgrammeStartDate() is null)
+        {
+            NextPagePath = linkGenerator.SocialWorkerProgrammeDates();
+        }
+        else
+        {
+            NextPagePath = linkGenerator.ConfirmAccountDetails();
+        }
 
-    public PageResult OnGetChange()
-    {
-        FromChangeLink = true;
-        return OnGet();
+        return Page();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingNotAvailable.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityFundingNotAvailable.cshtml.cs
@@ -20,7 +20,8 @@ public class EligibilityFundingNotAvailable(
         BackLinkPath = createAccountJourneyService.GetIsAgencyWorker() == true
             ? linkGenerator.EligibilityAgencyWorker()
             : linkGenerator.EligibilityQualification();
-        NextPagePath = FromChangeLink ? linkGenerator.ConfirmAccountDetails() : linkGenerator.AddAccountDetails();
+        var accountDetails = createAccountJourneyService.GetAccountDetails();
+        NextPagePath = FromChangeLink && accountDetails?.SocialWorkEnglandNumber is not null ? linkGenerator.ConfirmAccountDetails() : linkGenerator.AddAccountDetails();
         return Page();
     }
 

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityQualification.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EligibilityQualification.cshtml.cs
@@ -42,12 +42,6 @@ public class EligibilityQualification(
         }
 
         createAccountJourneyService.SetIsRecentlyQualified(IsRecentlyQualified);
-        if (FromChangeLink)
-        {
-            return Redirect(IsRecentlyQualified is false
-                ? linkGenerator.EligibilityFundingNotAvailableChange()
-                : linkGenerator.EligibilityFundingAvailableChange());
-        }
 
         return Redirect(IsRecentlyQualified is false
             ? linkGenerator.EligibilityFundingNotAvailable()
@@ -58,11 +52,5 @@ public class EligibilityQualification(
     {
         FromChangeLink = true;
         return OnGet();
-    }
-
-    public async Task<IActionResult> OnPostChangeAsync()
-    {
-        FromChangeLink = true;
-        return await OnPostAsync();
     }
 }

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectAccountType.cshtml.cs
@@ -43,11 +43,14 @@ public class SelectAccountType(
 
         if (FromChangeLink)
         {
+            if (createAccountJourneyService.GetIsRegisteredWithSocialWorkEngland() is null)
+            {
+                return linkGenerator.EligibilityInformation();
+            }
             if (details?.SocialWorkEnglandNumber is null)
             {
                 return linkGenerator.AddAccountDetailsChange();
             }
-
             return linkGenerator.ConfirmAccountDetails();
         }
 

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml.cs
@@ -3,7 +3,6 @@ using Dfe.Sww.Ecf.Frontend.Extensions;
 using Dfe.Sww.Ecf.Frontend.Models;
 using Dfe.Sww.Ecf.Frontend.Pages.Shared;
 using Dfe.Sww.Ecf.Frontend.Routing;
-using Dfe.Sww.Ecf.Frontend.Services.Interfaces;
 using Dfe.Sww.Ecf.Frontend.Services.Journeys.Interfaces;
 using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
@@ -31,6 +30,7 @@ public class SelectUseCase(
     public async Task<IActionResult> OnPostAsync()
     {
         var validationResult = await validator.ValidateAsync(this);
+        var captureSocialWorkEnglandNumber = false;
         if (SelectedAccountTypes is null || !validationResult.IsValid)
         {
             validationResult.AddToModelState(ModelState);
@@ -38,13 +38,47 @@ public class SelectUseCase(
             return Page();
         }
 
+        if (FromChangeLink)
+        {
+            SocialWorkEnglandNumberClearOrMarkForCapture(out captureSocialWorkEnglandNumber);
+        }
+
         createAccountJourneyService.SetAccountTypes(SelectedAccountTypes);
-        return Redirect(FromChangeLink ? linkGenerator.ConfirmAccountDetails() : linkGenerator.AddAccountDetails());
+        return Redirect(FromChangeLink && !captureSocialWorkEnglandNumber ? linkGenerator.ConfirmAccountDetails() : linkGenerator.AddAccountDetails());
     }
 
     public async Task<IActionResult> OnPostChangeAsync()
     {
         FromChangeLink = true;
         return await OnPostAsync();
+    }
+
+    private void SocialWorkEnglandNumberClearOrMarkForCapture(out bool captureSocialWorkEnglandNumber)
+    {
+        var accountDetails = createAccountJourneyService.GetAccountDetails();
+        captureSocialWorkEnglandNumber = false;
+        if (SelectedAccountTypes?.Count == 1 && SelectedAccountTypes[0] == AccountType.Coordinator)
+        {
+            if (accountDetails is not null && accountDetails.SocialWorkEnglandNumber is not null)
+            {
+                var updatedAccountDetails = new AccountDetails
+                {
+                    FirstName = accountDetails.FirstName,
+                    LastName = accountDetails.LastName,
+                    MiddleNames = accountDetails.MiddleNames,
+                    Email = accountDetails.Email,
+                    SocialWorkEnglandNumber = null,
+                    IsStaff = accountDetails.IsStaff,
+                    Types = accountDetails.Types
+                };
+                createAccountJourneyService.SetAccountDetails(updatedAccountDetails);
+            }
+        } else if (SelectedAccountTypes?.Contains(AccountType.Assessor) == true)
+        {
+            if (accountDetails is not null && accountDetails.SocialWorkEnglandNumber is null)
+            {
+                captureSocialWorkEnglandNumber = true;
+            }
+        }
     }
 }

--- a/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
+++ b/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
@@ -119,9 +119,7 @@ public abstract class EcfLinkGenerator(
     public string EligibilityQualification() => GetRequiredPathByPage("/ManageAccounts/EligibilityQualification");
     public string EligibilityQualificationChange() => GetRequiredPathByPage("/ManageAccounts/EligibilityQualification", handler: "Change");
     public string EligibilityFundingNotAvailable() => GetRequiredPathByPage("/ManageAccounts/EligibilityFundingNotAvailable");
-    public string EligibilityFundingNotAvailableChange() => GetRequiredPathByPage("/ManageAccounts/EligibilityFundingNotAvailable", handler: "Change");
     public string EligibilityFundingAvailable() => GetRequiredPathByPage("/ManageAccounts/EligibilityFundingAvailable");
-    public string EligibilityFundingAvailableChange() => GetRequiredPathByPage("/ManageAccounts/EligibilityFundingAvailable", handler: "Change");
     public string SocialWorkerProgrammeDates() => GetRequiredPathByPage("/ManageAccounts/SocialWorkerProgrammeDates");
 
     // SWE registration links


### PR DESCRIPTION
Changes for [SWIP-694](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-694) including:
- logic for change account type behaviour for staff accounts (capturing SWE number when accounts include assessor, clearing SWE when account changes to coordinator)
- logic for change account type behaviour when changing from staff to ECSW (capturing ECSW specific details)
- logic changes for eligible and not eligible ECSW flows depending on whether SWE number needs capturing or not based on account type changes
- unit tests
- logic changes for next page after agency worker (TBC with Victoria)