### PR TITLE
SWIP-903 - Register DB Seed options with DI

### DIFF
--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/SignInJourneyHelper.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/SignInJourneyHelper.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using Dfe.Sww.Ecf.AuthorizeAccess.Infrastructure.Security;
 using Dfe.Sww.Ecf.Core.DataStore.Postgres;
 using Dfe.Sww.Ecf.Core.DataStore.Postgres.Models;
+using Dfe.Sww.Ecf.Core.Infrastructure.Configuration;
 using Dfe.Sww.Ecf.Core.Services.Accounts;
 using Dfe.Sww.Ecf.UiCommon.FormFlow;
 using Dfe.Sww.Ecf.UiCommon.FormFlow.State;
@@ -20,7 +21,8 @@ public class SignInJourneyHelper(
     AuthorizeAccessLinkGenerator linkGenerator,
     IOptions<AuthorizeAccessOptions> optionsAccessor,
     IUserInstanceStateProvider userInstanceStateProvider,
-    IClock clock
+    IClock clock,
+    IOptions<DatabaseSeedOptions> databaseSeedOptionsAccessor
 )
 {
     public const string AuthenticationOnlyVtr = """["Cl.Cm"]""";
@@ -113,6 +115,12 @@ public class SignInJourneyHelper(
             oneLoginUser.FirstSignIn = clock.UtcNow;
             oneLoginUser.LastSignIn = clock.UtcNow;
             oneLoginUser.MatchRoute = OneLoginUserMatchRoute.LinkingToken;
+        }
+
+        if (oneLoginUser.PersonId is null && email == databaseSeedOptionsAccessor.Value.OneLoginEmail)
+        {
+            oneLoginUser.PersonId = databaseSeedOptionsAccessor.Value.PersonId;
+            oneLoginUser.MatchRoute = OneLoginUserMatchRoute.Automatic;
         }
 
         await dbContext.SaveChangesAsync();

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/appsettings.Development.json
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/appsettings.Development.json
@@ -84,7 +84,6 @@
     "OrganisationName": "Test Organisation",
     "PersonId": "00000000-0000-0000-0001-000000000001",
     "RoleId": 800,
-    "OneLoginSubject": "urn:fdc:gov.uk:2022:KaCIMs1jlJNWz-TQ9Rq8McFXfBwy6JgYbsUNLIEpqKo",
     "OneLoginEmail": "swip.test@education.gov.uk"
   },
   // Local simulator

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DatabaseSeeder.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DatabaseSeeder.cs
@@ -60,23 +60,4 @@ public static class DatabaseSeeder
             ct
         );
     }
-
-    public static async Task SeedOneLoginUserAsync(DbContext db, string oneLoginSubject, string oneLoginEmail,
-        Guid personId, CancellationToken ct)
-    {
-        await db.Set<OneLoginUser>().AddIfNotExistsAsync(
-            oneLoginUser => oneLoginUser.Subject == oneLoginSubject,
-            () =>
-                new OneLoginUser
-                {
-                    Subject = oneLoginSubject,
-                    PersonId = personId,
-                    Email = oneLoginEmail,
-                    MatchRoute = OneLoginUserMatchRoute.Automatic,
-                    FirstOneLoginSignIn = DateTime.UtcNow,
-                    LastOneLoginSignIn = DateTime.UtcNow
-                },
-            ct
-        );
-    }
 }

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DbContextOptionsBuilderExtensions.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DbContextOptionsBuilderExtensions.cs
@@ -14,8 +14,6 @@ public static class DbContextOptionsBuilderExtensions
             await DatabaseSeeder.SeedPersonAsync(db, seedOptions.PersonId, ct);
             await DatabaseSeeder.SeedPersonOrganisationAsync(db, seedOptions.OrganisationId, seedOptions.PersonId, ct);
             await DatabaseSeeder.SeedPersonRoleAsync(db, seedOptions.PersonId, seedOptions.RoleId, ct);
-            await DatabaseSeeder.SeedOneLoginUserAsync(db, seedOptions.OneLoginSubject, seedOptions.OneLoginEmail,
-                seedOptions.PersonId, ct);
 
             await db.SaveChangesAsync(ct);
         });

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/Infrastructure/Configuration/DatabaseSeedOptions.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/Infrastructure/Configuration/DatabaseSeedOptions.cs
@@ -6,6 +6,5 @@ public class DatabaseSeedOptions
     public string OrganisationName { get; init; } = string.Empty;
     public Guid PersonId { get; init; }
     public int RoleId { get; init; }
-    public string OneLoginSubject { get; init; } = string.Empty;
     public string OneLoginEmail { get; init; } = string.Empty;
 }

--- a/terraform/envs/d01/env.tfvars
+++ b/terraform/envs/d01/env.tfvars
@@ -29,7 +29,6 @@ auth_service_app_settings = {
   "DATABASESEED__ORGANISATIONNAME"             = "Test Organisation"
   "DATABASESEED__PERSONID"                     = "00000000-0000-0000-0001-000000000001"
   "DATABASESEED__ROLEID"                       = 800
-  "DATABASESEED__ONELOGINSUBJECT"              = "urn:fdc:gov.uk:2022:KaCIMs1jlJNWz-TQ9Rq8McFXfBwy6JgYbsUNLIEpqKo"
   "DATABASESEED__ONELOGINEMAIL"                = "swip.test@education.gov.uk"
 }
 one_login_client_id = "p4yA1KMFQIoQbqmtntQZPTfdN_I"

--- a/terraform/envs/d02/env.tfvars
+++ b/terraform/envs/d02/env.tfvars
@@ -31,7 +31,6 @@ auth_service_app_settings = {
   "DATABASESEED__ORGANISATIONNAME"             = "Test Organisation"
   "DATABASESEED__PERSONID"                     = "00000000-0000-0000-0001-000000000001"
   "DATABASESEED__ROLEID"                       = 800
-  "DATABASESEED__ONELOGINSUBJECT"              = "urn:fdc:gov.uk:2022:KaCIMs1jlJNWz-TQ9Rq8McFXfBwy6JgYbsUNLIEpqKo"
   "DATABASESEED__ONELOGINEMAIL"                = "swip.test@education.gov.uk"
 }
 one_login_client_id = "xCtiHWNyTayG6HcaeYMxBNP4t8U"

--- a/terraform/envs/d03/env.tfvars
+++ b/terraform/envs/d03/env.tfvars
@@ -31,7 +31,6 @@ auth_service_app_settings = {
   "DATABASESEED__ORGANISATIONNAME"             = "Test Organisation"
   "DATABASESEED__PERSONID"                     = "00000000-0000-0000-0001-000000000001"
   "DATABASESEED__ROLEID"                       = 800
-  "DATABASESEED__ONELOGINSUBJECT"              = "urn:fdc:gov.uk:2022:KaCIMs1jlJNWz-TQ9Rq8McFXfBwy6JgYbsUNLIEpqKo"
   "DATABASESEED__ONELOGINEMAIL"                = "swip.test@education.gov.uk"
 }
 one_login_client_id = "vZkWR2x4iDjtxvp22UolB4psq_Y"

--- a/terraform/envs/d04/env.tfvars
+++ b/terraform/envs/d04/env.tfvars
@@ -30,7 +30,6 @@ auth_service_app_settings = {
   "DATABASESEED__ORGANISATIONNAME"             = "Test Organisation"
   "DATABASESEED__PERSONID"                     = "00000000-0000-0000-0001-000000000001"
   "DATABASESEED__ROLEID"                       = 800
-  "DATABASESEED__ONELOGINSUBJECT"              = "urn:fdc:gov.uk:2022:KaCIMs1jlJNWz-TQ9Rq8McFXfBwy6JgYbsUNLIEpqKo"
   "DATABASESEED__ONELOGINEMAIL"                = "swip.test@education.gov.uk"
 }
 # Needs wiring up


### PR DESCRIPTION
This PR adds some logic that will automatically link the OneLogin account with an email that matches the one specified in `DatabaseSeedOptions.OneLoginEmail` to the `DatabaseSeedOptions.PersonId` when the user first logs in.

It also removes the previous code that would manually seed the OneLoginUsers table with a row for the one login user as the subject differs per environment which makes configuring/maintaining this approach difficult.