### PR TITLE
SWIP 903 auth errors

### DIFF
--- a/apps/user-management/apps/frontend/nginx-basic-auth.conf
+++ b/apps/user-management/apps/frontend/nginx-basic-auth.conf
@@ -18,6 +18,7 @@ server {
     proxy_buffer_size 128k;
     proxy_buffers 4 256k;
     proxy_busy_buffers_size 256k;
+    large_client_header_buffers 4 32k;
 
     # === Public health-check (no authentication) ===
     location = /version.txt {

--- a/apps/user-management/apps/frontend/nginx.conf
+++ b/apps/user-management/apps/frontend/nginx.conf
@@ -16,6 +16,7 @@ server {
     proxy_buffer_size 128k;
     proxy_buffers 4 256k;
     proxy_busy_buffers_size 256k;
+    large_client_header_buffers 4 32k;
 
     location / {
         # Forward relevant headers to Kestrel


### PR DESCRIPTION
Increase nginx buffer sizes to avoid 502 and 400 errors related to request header sizes being too large