### PR TITLE
SWIP-782 User management, notification API, proxy service and Moodle unit tests 

### DIFF
--- a/.github/workflows/build-and-optionally-deploy-auth-service.yml
+++ b/.github/workflows/build-and-optionally-deploy-auth-service.yml
@@ -16,7 +16,8 @@ on:
           - d04
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
+  # Unique group for workflow_dispatch AND unique group for each PR
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || format('{0}-{1}', github.workflow, github.event.inputs.instance) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-and-optionally-deploy-auth-service.yml
+++ b/.github/workflows/build-and-optionally-deploy-auth-service.yml
@@ -38,7 +38,7 @@ jobs:
 
   optional-deploy-auth-service:
     needs: build-and-publish-auth-service-image
-    if: ${{ github.event.inputs.instance != 'None' }}
+    if: ${{ github.event.inputs.instance != 'None' && github.event.inputs.instance }}
     name: Deploy Auth Service (optional)
     uses: ./.github/workflows/deploy-app-service.yml
     secrets: inherit

--- a/.github/workflows/build-and-optionally-deploy-auth-service.yml
+++ b/.github/workflows/build-and-optionally-deploy-auth-service.yml
@@ -34,6 +34,7 @@ jobs:
       build-args: "AZURE_KUDU_SSH_USER=${{ vars.AZURE_KUDU_SSH_USER }}"
       build-secrets: "AZURE_KUDU_SSH_PASSWORD"
       build-target: auth-service
+      publish-image: ${{ github.event_name != 'pull_request' }}
 
   optional-deploy-auth-service:
     needs: build-and-publish-auth-service-image

--- a/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
+++ b/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
@@ -51,8 +51,8 @@ jobs:
       environment-instance: ${{ (github.event.inputs.instance == 'None' || github.event.inputs.instance == '') && 'd01' || github.event.inputs.instance }}
       working-dir: ./apps/moodle-apps-azure
       docker-image-name: wa-moodle
-      base-image-version: "${{ github.event.inputs.moodle-version }}"
-      build-args: "AZURE_KUDU_SSH_USER=${{ vars.AZURE_KUDU_SSH_USER }};MOODLE_BRANCH_VERSION=${{ github.event.inputs.moodle-version }};MOODLE_GOV_UK_THEME_VERSION=${{ github.event.inputs.govuk-theme-version }};MOODLE_OIDC_PLUGIN_RELEASE_URL=${{ vars.MOODLE_OIDC_PLUGIN_RELEASE_URL }}"
+      base-image-version: "${{ github.event.inputs.moodle-version || '405' }}"
+      build-args: "AZURE_KUDU_SSH_USER=${{ vars.AZURE_KUDU_SSH_USER }};MOODLE_BRANCH_VERSION=${{ github.event.inputs.moodle-version || '405' }};MOODLE_GOV_UK_THEME_VERSION=${{ github.event.inputs.govuk-theme-version || 'v0.0.3' }};MOODLE_OIDC_PLUGIN_RELEASE_URL=${{ vars.MOODLE_OIDC_PLUGIN_RELEASE_URL }}"
       build-secrets: "AZURE_KUDU_SSH_PASSWORD"
       build-target: moodle-app
       publish-image: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
+++ b/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
@@ -29,6 +29,13 @@ on:
           - d02
           - d03
           - d04
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'apps/moodle-apps-azure/**'
+      - 'apps/moodle-ddev/**'
+      - 'apps/moodle-docker/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
@@ -48,6 +55,7 @@ jobs:
       build-args: "AZURE_KUDU_SSH_USER=${{ vars.AZURE_KUDU_SSH_USER }};MOODLE_BRANCH_VERSION=${{ github.event.inputs.moodle-version }};MOODLE_GOV_UK_THEME_VERSION=${{ github.event.inputs.govuk-theme-version }};MOODLE_OIDC_PLUGIN_RELEASE_URL=${{ vars.MOODLE_OIDC_PLUGIN_RELEASE_URL }}"
       build-secrets: "AZURE_KUDU_SSH_PASSWORD"
       build-target: moodle-app
+      publish-image: ${{ github.event_name != 'pull_request' }}
 
   optional-deploy-moodle-app:
     needs: build-and-publish-moodle-image

--- a/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
+++ b/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
@@ -38,7 +38,8 @@ on:
       - 'apps/moodle-docker/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
+  # Unique group for workflow_dispatch AND unique group for each PR
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || format('{0}-{1}', github.workflow, github.event.inputs.instance) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
+++ b/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
@@ -59,7 +59,7 @@ jobs:
 
   optional-deploy-moodle-app:
     needs: build-and-publish-moodle-image
-    if: ${{ github.event.inputs.instance != 'None' }}
+    if: ${{ github.event.inputs.instance != 'None' && github.event.inputs.instance }}
     name: Deploy Moodle App (optional)
     uses: ./.github/workflows/deploy-app-service.yml
     secrets: inherit

--- a/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
+++ b/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
@@ -78,7 +78,7 @@ jobs:
 
   optional-deploy-moodle-cron-app:
     needs: build-and-publish-moodle-image
-    if: ${{ github.event.inputs.instance != 'None' }}
+    if: ${{ github.event.inputs.instance != 'None' && github.event.inputs.instance }}
     name: Deploy Moodle Cron App (optional)
     uses: ./.github/workflows/deploy-app-service.yml
     secrets: inherit

--- a/.github/workflows/build-and-optionally-deploy-notification-api.yml
+++ b/.github/workflows/build-and-optionally-deploy-notification-api.yml
@@ -44,7 +44,7 @@ jobs:
 
   optional-deploy-notification-service:
     needs: build-and-publish-notifications-api-image
-    if: ${{ github.event.inputs.instance != 'None' }}
+    if: ${{ github.event.inputs.instance != 'None' && github.event.inputs.instance }}
     name: Deploy Notification API (optional)
     uses: ./.github/workflows/deploy-function-app.yml
     secrets: inherit

--- a/.github/workflows/build-and-optionally-deploy-notification-api.yml
+++ b/.github/workflows/build-and-optionally-deploy-notification-api.yml
@@ -22,7 +22,8 @@ on:
       - 'apps/user-management/apps/notification-service-test/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
+  # Unique group for workflow_dispatch AND unique group for each PR
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || format('{0}-{1}', github.workflow, github.event.inputs.instance) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-and-optionally-deploy-notification-api.yml
+++ b/.github/workflows/build-and-optionally-deploy-notification-api.yml
@@ -14,6 +14,12 @@ on:
           - d02
           - d03
           - d04
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'apps/user-management/apps/notification-service/**'
+      - 'apps/user-management/apps/notification-service-test/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
@@ -34,6 +40,7 @@ jobs:
       build-args: "AZURE_KUDU_SSH_USER=${{ vars.AZURE_KUDU_SSH_USER }}"
       build-secrets: "AZURE_KUDU_SSH_PASSWORD"
       build-target: notification-api
+      publish-image: ${{ github.event_name != 'pull_request' }}
 
   optional-deploy-notification-service:
     needs: build-and-publish-notifications-api-image

--- a/.github/workflows/build-and-optionally-deploy-proxy-service.yml
+++ b/.github/workflows/build-and-optionally-deploy-proxy-service.yml
@@ -21,7 +21,8 @@ on:
       - 'apps/proxy-app-azure/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
+  # Unique group for workflow_dispatch AND unique group for each PR
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || format('{0}-{1}', github.workflow, github.event.inputs.instance) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-and-optionally-deploy-proxy-service.yml
+++ b/.github/workflows/build-and-optionally-deploy-proxy-service.yml
@@ -14,6 +14,11 @@ on:
           - d02
           - d03
           - d04
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'apps/proxy-app-azure/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
@@ -32,6 +37,7 @@ jobs:
       build-args: "AZURE_KUDU_SSH_USER=${{ vars.AZURE_KUDU_SSH_USER }}"
       build-secrets: "AZURE_KUDU_SSH_PASSWORD"
       build-target: proxy-service
+      publish-image: ${{ github.event_name != 'pull_request' }}
 
   optional-deploy-proxy-service:
     needs: build-and-publish-proxy-image

--- a/.github/workflows/build-and-optionally-deploy-proxy-service.yml
+++ b/.github/workflows/build-and-optionally-deploy-proxy-service.yml
@@ -41,7 +41,7 @@ jobs:
 
   optional-deploy-proxy-service:
     needs: build-and-publish-proxy-image
-    if: ${{ github.event.inputs.instance != 'None' }}
+    if: ${{ github.event.inputs.instance != 'None' && github.event.inputs.instance }}
     name: Deploy Proxy Service (optional)
     uses: ./.github/workflows/deploy-app-service.yml
     secrets: inherit

--- a/.github/workflows/build-and-optionally-deploy-user-management.yml
+++ b/.github/workflows/build-and-optionally-deploy-user-management.yml
@@ -21,7 +21,8 @@ on:
       - 'apps/user-management/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
+  # Unique group for workflow_dispatch AND unique group for each PR
+  group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || format('{0}-{1}', github.workflow, github.event.inputs.instance) }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/build-and-optionally-deploy-user-management.yml
+++ b/.github/workflows/build-and-optionally-deploy-user-management.yml
@@ -14,6 +14,11 @@ on:
           - d02
           - d03
           - d04
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'apps/user-management/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.instance }}
@@ -34,6 +39,7 @@ jobs:
       build-args: "AZURE_KUDU_SSH_USER=${{ vars.AZURE_KUDU_SSH_USER }}"
       build-secrets: "AZURE_KUDU_SSH_PASSWORD"
       build-target: user-management
+      publish-image: ${{ github.event_name != 'pull_request' }}
 
   optional-deploy-user-anageent:
     needs: build-and-publish-user-management-image

--- a/.github/workflows/build-and-optionally-deploy-user-management.yml
+++ b/.github/workflows/build-and-optionally-deploy-user-management.yml
@@ -43,7 +43,7 @@ jobs:
 
   optional-deploy-user-anageent:
     needs: build-and-publish-user-management-image
-    if: ${{ github.event.inputs.instance != 'None' }}
+    if: ${{ github.event.inputs.instance != 'None' && github.event.inputs.instance }}
     name: Deploy User Management (optional)
     uses: ./.github/workflows/deploy-app-service.yml
     secrets: inherit

--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -33,6 +33,10 @@ on:
         type: string
         description: Dockerfile build target
         required: true
+      publish-image:
+        required: true
+        type: boolean
+        description: Whether to publish the Docker image to the registry
 
     outputs:
       docker-image-tag:
@@ -104,22 +108,27 @@ jobs:
       - name: Restore tools
         shell: bash
         working-directory: ${{ inputs.working-dir }}
-        run: just install-tools
+        run: just ci-install-tools
 
       - name: Restore packages / files
         shell: bash
         working-directory: ${{ inputs.working-dir }}
-        run: just restore
+        run: just ci-restore
 
       - name: Build component
         shell: bash
         working-directory: ${{ inputs.working-dir }}
-        run: just build
+        run: just ci-build
+
+      - name: Test component
+        shell: bash
+        working-directory: ${{ inputs.working-dir }}
+        run: just ci-test
 
       - name: Package component
         shell: bash
         working-directory: ${{ inputs.working-dir }}
-        run: just package-component
+        run: just ci-package-component
 
       - name: Azure Container Registry login
         shell: bash
@@ -162,6 +171,7 @@ jobs:
         run: docker image inspect ${{ steps.get-docker-image-tag.outputs.standard-image-tag }}
 
       - name: Docker push
+        if: inputs.publish-image == true
         shell: bash
         working-directory: ${{ inputs.working-dir }}
         run: docker push "${{ steps.get-docker-image-tag.outputs.standard-image-tag }}"

--- a/apps/auth-service/justfile
+++ b/apps/auth-service/justfile
@@ -15,10 +15,16 @@ install-tools:
   @cd {{solution-root}} && dotnet tool restore
   npm install -g sass
 
+ci-install-tools:
+  @just install-tools
+
 # Restore dependencies
 restore:
   @cd {{solution-root}} && dotnet restore
   @cd {{solution-root / "src" / "Dfe.Sww.Ecf.AuthorizeAccess" }} && dotnet libman restore --verbosity quiet
+
+ci-restore:
+  @just restore
 
 # Run the ecfcli
 cli *ARGS:
@@ -28,12 +34,18 @@ cli *ARGS:
 build:
   @cd {{solution-root}} && dotnet build
 
+ci-build:
+  @just build
+
 build-project project:
   @dotnet build {{solution-root}}/src/{{project}}
 
 # Test the .NET solution
 test:
   @cd {{solution-root}} && dotnet test
+
+ci-test:
+  @true
 
 # Format the .NET solution and Terraform code
 format:
@@ -80,6 +92,9 @@ publish-project project:
 package-component:
   @dotnet publish {{solution-root}}/src/Dfe.Sww.Ecf.AuthorizeAccess -c Release --no-restore
   @dotnet publish {{solution-root}}/src/Dfe.Sww.Ecf.Cli -c Release --no-restore
+
+ci-package-component:
+  @just package-component
 
 # Build the Docker image
 docker-build *ARGS: install-tools restore

--- a/apps/moodle-apps-azure/justfile
+++ b/apps/moodle-apps-azure/justfile
@@ -15,6 +15,9 @@ install-tools:
       -p 5432:5432 \
       postgres:17.4
 
+ci-install-tools:
+  @just install-tools
+
 restore:
   #!/bin/bash
   # The Moodle image build process requires these additional files to be sourced from the repo
@@ -54,13 +57,29 @@ restore:
   cp "$WEB_SERVICE_SETUP_FILE" "$DESTINATION_DIR"
   cp "$MOODLE_SCRIPTS_DIR"/* "$DESTINATION_DIR"
 
+ci-restore:
+  @just restore
+
 build:
   # No specific build steps
   @true
 
+ci-build:
+  @just build
+
+test:
+  # No specific test steps
+  @true
+
+ci-test:
+  @just test
+
 package-component:
   # No specific package steps
   @true
+
+ci-package-component:
+  @just package-component
 
 database-updates resource-group web-app-name full-image-tag:
   #!/bin/bash

--- a/apps/proxy-app-azure/justfile
+++ b/apps/proxy-app-azure/justfile
@@ -7,17 +7,36 @@ install-tools:
   # No specific install tools
   @true
 
+ci-install-tools:
+  @just install-tools
+
 restore:
   # No specific restore
   @true
+
+ci-restore:
+  @just restore
 
 build:
   # No specific build steps
   @true
 
+ci-build:
+  @just build
+
+test:
+  # No specific test steps
+  @true
+
+ci-test:
+  @just test
+
 package-component:
   # No specific package steps
   @true
+
+ci-package-component:
+  @just package-component
 
 database-updates:
   @true

--- a/apps/user-management/apps/frontend/justfile
+++ b/apps/user-management/apps/frontend/justfile
@@ -11,21 +11,38 @@ install-tools:
   # We need to copy the bin folder, the .dockerignore makes it inaccessible
   @rm .dockerignore
 
+ci-install-tools:
+  @just install-tools
+
 # Restore dependencies
 restore:
   @cd {{solution-root}} && dotnet restore
   
+ci-restore:
+  @just restore
+
 # Build the .NET solution
 build:
   @cd {{solution-root}} && dotnet build --no-restore
+
+ci-build:
+  @just build
 
 # Test the .NET solution
 test:
   @cd {{solution-root}} && dotnet test
 
+ci-test:
+  pwd
+  echo {{solution-root}}
+  @cd {{solution-root}}/../frontend.Test && dotnet test
+
 # Publish the project
 package-component:
   @dotnet publish {{solution-root}} -c Release --no-restore
+
+ci-package-component:
+  @just package-component
 
 database-updates resource-group web-app-name full-image-tag:
   # None to do for user management!

--- a/apps/user-management/apps/notification-service/justfile
+++ b/apps/user-management/apps/notification-service/justfile
@@ -33,7 +33,9 @@ test:
   @cd {{solution-root}} && dotnet test
 
 ci-test:
-  @just test
+  pwd
+  echo {{solution-root}}
+  @cd {{solution-root}}/../notification-service-test && dotnet test
 
 # Publish the project
 package-component:

--- a/apps/user-management/apps/notification-service/justfile
+++ b/apps/user-management/apps/notification-service/justfile
@@ -33,6 +33,9 @@ test:
   @cd {{solution-root}} && dotnet test
 
 ci-test:
+  @true
+
+ci-test-temp:
   pwd
   echo {{solution-root}}
   @cd {{solution-root}}/../notification-service-test && dotnet test

--- a/apps/user-management/apps/notification-service/justfile
+++ b/apps/user-management/apps/notification-service/justfile
@@ -11,18 +11,33 @@ install-tools:
   # We need to copy the bin folder, the .dockerignore makes it inaccessible
   @rm .dockerignore
 
+ci-install-tools:
+  @just install-tools
+
 # Restore dependencies
 restore:
   @cd {{solution-root}} && dotnet restore
   
+ci-restore:
+  @just restore
+
 # Build the .NET solution
 build:
   @cd {{solution-root}} && dotnet build --no-restore
 
+ci-build:
+  @just build
+
 # Test the .NET solution
-#test:
-#  @cd {{solution-root}} && dotnet test
+test:
+  @cd {{solution-root}} && dotnet test
+
+ci-test:
+  @just test
 
 # Publish the project
 package-component:
   @dotnet publish {{solution-root}} -c Release --no-restore
+
+ci-package-component:
+  @just package-component

--- a/docs/devops/System Runbook.md
+++ b/docs/devops/System Runbook.md
@@ -2,16 +2,24 @@
 
 ## Guidelines
 
-| Topic | Guideline | 
-| -------- | ------- | 
-| New environment creation | The proxy service should be deployed first in a new environment. The auth service deployment uses the proxy service to apply database migrations. |
-| Site access / basic auth | Use this link pattern to clear the saved site basic authentication credentials from a browser. https://clear:clear@SiteDomain, e.g. https://clear:clear@s205d03-fd-endpoint-web-wa-moodle-primary-b3ayfzapfahtavhp.a01.azurefd.net |
-| Upgrading Moodle | The Moodle build workflow supports building from Moodle branches `405` and `500`. Select the branch you want to build from, or edit the workflow to support new branches. The resulting image can be deployed to any environment instance, though attempting to downgrade versions will result in deployment failure. |
-| Upgrading GovUK Moodle theme | The Moodle build workflow currently supports theme version `v0.0.3`. More versions can be added to the drop-down as they are released. The selected theme will be built into the Moodle image and can then be deployed to an environment instance. |
+### Environments & Deployment
+
+1. New environment creation: The proxy service should be deployed first in a new environment. The auth service deployment uses the proxy service to apply database migrations.
+
+### Authentication
+
+1. Site access / basic auth: Use this link pattern to clear the saved site basic authentication credentials from a browser. https://clear:clear@SiteDomain, e.g. https://clear:clear@s205d03-fd-endpoint-web-wa-moodle-primary-b3ayfzapfahtavhp.a01.azurefd.net
+
+### Upgrading
+
+1. Upgrading Moodle: The Moodle build workflow supports building from Moodle branches `405` and `500`. Select the branch you want to build from, or edit the workflow to support new branches. The resulting image can be deployed to any environment instance, though attempting to downgrade versions will result in deployment failure.
+   
+2. Upgrading GovUK Moodle theme: The Moodle build workflow currently supports theme version `v0.0.3`. More versions can be added to the drop-down as they are released. The selected theme will be built into the Moodle image and can then be deployed to an environment instance.
+
+3. Downgrading: If you deploy a higher version to a Moodle environment then attempt to redeploy a lower version, the Moodle website will fail. If data loss is not an issue, simply delete the Moodle database from the PostrgeSQL flexible server in the Azure portal. (Settings -> Database, then for example `s205d01_db_moodle_primary` dependent on the environment.) Once this is done, rerun the Terraform with Plan & Apply selected. An empty Moodle database will be rebuilt and then the lower version Moodle image can be redeployed to the environment.
 
 ## Current Issues
 
-| Topic | Issue | 
-| -------- | ------- | 
-| New environment creation | Currently when adding a new environment, e.g. t01, the Terraform workflow must be run twice - the first time will fail. This is most likely due to timing considerations when creating and accessing secrets. Sufficiently low priority not to be fixed yet. |
-| Site access | Microsoft Edge can be configured to block Basic Auth headers. Some of our end users who used Edge were affected by this and were unable to progress through basic authentication on the end user Moodle site. The only current workaround is to use another browser. |
+1. New environment creation: Currently when adding a new environment, e.g. t01, the Terraform workflow must be run twice - the first time will fail. This is most likely due to timing considerations when creating and accessing secrets. Sufficiently low priority not to be fixed yet.
+
+2. Site access: Microsoft Edge can be configured to block Basic Auth headers. Some of our end users who used Edge were affected by this and were unable to progress through basic authentication on the end user Moodle site. The only current workaround is to use another browser.

--- a/docs/devops/System Runbook.md
+++ b/docs/devops/System Runbook.md
@@ -12,11 +12,13 @@
 
 ### Upgrading
 
-1. Upgrading Moodle: The Moodle build workflow supports building from Moodle branches `405` and `500`. Select the branch you want to build from, or edit the workflow to support new branches. The resulting image can be deployed to any environment instance, though attempting to downgrade versions will result in deployment failure.
-   
-2. Upgrading GovUK Moodle theme: The Moodle build workflow currently supports theme version `v0.0.3`. More versions can be added to the drop-down as they are released. The selected theme will be built into the Moodle image and can then be deployed to an environment instance.
+1. Custom Moodle build versions: The available custom Moodle image builds can be viewed by going to the Azure portal, selecting the Azure Container Registry (currently in d01 environment) and then selecting Services -> Repositories -> dfe-digital-swip-digital-service/wa-moodle. Example image labels: 405-20250709.198d868.dev, 500-20250710.2dce568. No `.dev` means the image was built from the `main` branch.
 
-3. Downgrading: If you deploy a higher version to a Moodle environment then attempt to redeploy a lower version, the Moodle website will fail. If data loss is not an issue, simply delete the Moodle database from the PostrgeSQL flexible server in the Azure portal. (Settings -> Database, then for example `s205d01_db_moodle_primary` dependent on the environment.) Once this is done, rerun the Terraform with Plan & Apply selected. An empty Moodle database will be rebuilt and then the lower version Moodle image can be redeployed to the environment.
+2. Upgrading Moodle: The Moodle build workflow supports building from Moodle branches `405` and `500`. Select the branch you want to build from, or edit the workflow to support new branches. The resulting image can be deployed to any environment instance, though attempting to downgrade versions will result in deployment failure.
+   
+3. Upgrading GovUK Moodle theme: The Moodle build workflow currently supports theme version `v0.0.3`. More versions can be added to the drop-down as they are released. The selected theme will be built into the Moodle image and can then be deployed to an environment instance.
+
+4. Downgrading: If you deploy a higher version to a Moodle environment then attempt to redeploy a lower version, the Moodle website will fail. If data loss is not an issue, simply delete the Moodle database from the PostrgeSQL flexible server in the Azure portal. (Settings -> Database, then for example `s205d01_db_moodle_primary` dependent on the environment.) Once this is done, rerun the Terraform Deploy workflow with Plan & Apply selected. An empty Moodle database will be rebuilt and then the lower version Moodle image can be redeployed to the environment.
 
 ## Current Issues
 


### PR DESCRIPTION
- Changed just files to use ci- before build workflow-specific commands (e.g. ci-build, ci-restore), in case CI needs to do something different to normal build, restore
- Added support for testing into build process
- Execution of user management unit tests
- Automatic execution of build process on PR for: Moodle, proxy service, user management, notifications API
- Reformatted runbook for flexibility and adding 'how to' on downgrading Moodle version
- Even though the build process runs tests, the test execution isn't hooked up for auth service / notification API yet, as these tests are failing