### PR TITLE
SWIP 783 Ensure monorepo workflows run auth service unit tests on PRs

### DIFF
--- a/.github/workflows/build-and-optionally-deploy-auth-service.yml
+++ b/.github/workflows/build-and-optionally-deploy-auth-service.yml
@@ -14,6 +14,11 @@ on:
           - d02
           - d03
           - d04
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'apps/auth-service/**'
 
 concurrency:
   # Unique group for workflow_dispatch AND unique group for each PR

--- a/apps/auth-service/justfile
+++ b/apps/auth-service/justfile
@@ -45,7 +45,7 @@ test:
   @cd {{solution-root}} && dotnet test
 
 ci-test:
-  @true
+  @true 
 
 # Format the .NET solution and Terraform code
 format:


### PR DESCRIPTION
- Note that the build-and-optionally-deploy-auth-service.yml workflow will trigger on PR, but the running of tests is currently disabled in /apps/auth-service.justfile
- Getting the tests working and re-enabling the tests will be addressed by a separate ticket