### PR TITLE
SWIP 907 Moodle cron service fix

### DIFF
--- a/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
+++ b/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
@@ -78,7 +78,9 @@ jobs:
       version-endpoint-path: /version.txt
 
   optional-deploy-moodle-cron-app:
-    needs: build-and-publish-moodle-image
+    needs: 
+      - build-and-publish-moodle-image
+      - optional-deploy-moodle-app
     if: ${{ github.event.inputs.instance != 'None' && github.event.inputs.instance }}
     name: Deploy Moodle Cron App (optional)
     uses: ./.github/workflows/deploy-app-service.yml

--- a/.github/workflows/deploy-moodle-app.yml
+++ b/.github/workflows/deploy-moodle-app.yml
@@ -44,6 +44,7 @@ jobs:
 
   deploy-moodle-cron-app:
     if: ${{ github.event.inputs.instance != 'None' }}
+    needs: deploy-moodle-app
     name: Deploy Moodle Cron App
     uses: ./.github/workflows/deploy-app-service.yml
     secrets: inherit

--- a/apps/moodle-apps-azure/Dockerfile
+++ b/apps/moodle-apps-azure/Dockerfile
@@ -178,9 +178,7 @@ RUN a2enmod headers
 
 # Give the cron job some html to serve - the cron job service is still an app service
 # and needs to serve something
-RUN mkdir -p /var/www/html/cron
-COPY index.html /var/www/html/cron/index.html
-RUN chown -R www-data:www-data /var/www/html/cron
+COPY --chown=www-data:www-data index.html /var/www/html/public/index.html
 
 CMD ["/app/entry-point.sh"]
 

--- a/apps/moodle-apps-azure/apache-config-cron.conf
+++ b/apps/moodle-apps-azure/apache-config-cron.conf
@@ -9,7 +9,7 @@
         #ServerName www.example.com
 
         ServerAdmin webmaster@localhost
-        DocumentRoot /var/www/html/cron
+        DocumentRoot /var/www/html/public
         DirectoryIndex index.html
 
         # Available loglevels: trace8, ..., trace1, debug, info, notice, warn,
@@ -20,6 +20,19 @@
 
         ErrorLog ${APACHE_LOG_DIR}/error.log
         CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+        <Location "/version.txt">
+                Require all granted
+        </Location>
+
+        <Location "/index.html">
+                Require all granted
+        </Location>
+
+        # Deny everything else
+        <LocationMatch "^/(?!version\.txt$|index\.html$)">
+                Require all denied
+        </LocationMatch>
 
         # For most configuration files from conf-available/, which are
         # enabled or disabled at a global level, it is possible to

--- a/apps/moodle-apps-azure/entry-point.sh
+++ b/apps/moodle-apps-azure/entry-point.sh
@@ -23,7 +23,6 @@ log "Cron configuration, IS_CRON_JOB_ONLY: $IS_CRON_JOB_ONLY"
 if [[ "$IS_CRON_JOB_ONLY" == 'true' ]]; then
     log "Switching to cron-only mode..."
     cp /app/apache-config-cron.conf /etc/apache2/sites-available/000-default.conf
-    mv /var/www/html/public/version.txt /var/www/html/cron/version.txt
 
     # It was too involved to get cron to inherit all of the environment variables for
     # Moodle and php, so create a simple background process here. All of the necessary


### PR DESCRIPTION
- index.html and version.txt were no longer being served (permission denied)
- Made Moodle cron service dependent on main Moodle site so initial deployments are fully installed before the cron service is deployed