### PR TITLE
SWIP-818 change existing staff account type

### DIFF
--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EditAccountDetailsPageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/EditAccountDetailsPageTests.cs
@@ -33,7 +33,7 @@ public class EditAccountDetailsPageTests : ManageAccountsPageTestBase<EditAccoun
         // Arrange
         var account = AccountBuilder.Build();
         var accountDetails = AccountDetails.FromAccount(account);
-        var expectedShowSweInput = (account.Types?.Contains(AccountType.EarlyCareerSocialWorker) ?? false) || (account.Types?.Contains(AccountType.Assessor) ?? false);
+        var expectedShowSweInput = (accountDetails.Types?.Contains(AccountType.EarlyCareerSocialWorker) ?? false) || (accountDetails.Types?.Contains(AccountType.Assessor) ?? false);
 
         var isSwe = SocialWorkEnglandRecord.TryParse(account.SocialWorkEnglandNumber, out var swe);
         var socialWorkerId = isSwe ? swe?.GetNumber().ToString() : null;
@@ -59,7 +59,6 @@ public class EditAccountDetailsPageTests : ManageAccountsPageTestBase<EditAccoun
         Sut.BackLinkPath.Should().Be("/manage-accounts/view-account-details/" + account.Id);
 
         MockEditAccountJourneyService.Verify(x => x.GetAccountDetailsAsync(account.Id), Times.Once);
-        MockEditAccountJourneyService.Verify(x => x.GetAccountTypesAsync(account.Id), Times.Once);
         VerifyAllNoOtherCalls();
     }
 
@@ -90,6 +89,7 @@ public class EditAccountDetailsPageTests : ManageAccountsPageTestBase<EditAccoun
             .WithAddOrEditAccountDetailsData()
             .Build();
         var accountDetails = AccountDetails.FromAccount(account);
+        var expectedShowSweInput = (accountDetails.Types?.Contains(AccountType.EarlyCareerSocialWorker) ?? false) || (accountDetails.Types?.Contains(AccountType.Assessor) ?? false);
 
         MockEditAccountJourneyService
             .Setup(x => x.IsAccountIdValidAsync(account.Id))
@@ -104,7 +104,6 @@ public class EditAccountDetailsPageTests : ManageAccountsPageTestBase<EditAccoun
         Sut.LastName = account.LastName;
         Sut.Email = account.Email;
         Sut.SocialWorkEnglandNumber = account.SocialWorkEnglandNumber;
-        Sut.ShowSweInput = account.IsStaff;
 
         // Act
         var result = await Sut.OnPostAsync(account.Id);
@@ -117,7 +116,7 @@ public class EditAccountDetailsPageTests : ManageAccountsPageTestBase<EditAccoun
         redirectResult!
             .Url.Should()
             .Be("/manage-accounts/confirm-account-details/" + account.Id + "?handler=Update");
-
+        Sut.ShowSweInput.Should().Be(expectedShowSweInput);
         MockEditAccountJourneyService.Verify(x => x.IsAccountIdValidAsync(account.Id), Times.Once);
         MockEditAccountJourneyService.Verify(
             x =>

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/SelectUseCasePageTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageAccounts/SelectUseCasePageTests.cs
@@ -251,7 +251,7 @@ public class SelectUseCasePageTests : ManageAccountsPageTestBase<SelectUseCase>
         Sut.Id = id;
         Sut.SelectedAccountTypes = new List<AccountType> { AccountType.Coordinator };
 
-        var updatedAccountDetails = accountDetails;
+        var updatedAccountDetails = AccountDetails.FromAccount(account);
         updatedAccountDetails.SocialWorkEnglandNumber = null;
 
         // Act

--- a/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/EditAccountJourneyServiceTests/GetAccountTypesShould.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/EditAccountJourneyServiceTests/GetAccountTypesShould.cs
@@ -24,7 +24,7 @@ public class GetAccountTypesShould : EditAccountJourneyServiceTestBase
         // Assert
         response.Should().NotBeNull();
         response.Should().BeOfType<ImmutableList<AccountType>?>();
-        response.Should().BeEquivalentTo(expected.AccountTypes);
+        response.Should().BeEquivalentTo(expected.AccountDetails.Types);
 
         MockAccountService.Verify(x => x.GetByIdAsync(account.Id), Times.Once);
         VerifyAllNoOtherCall();

--- a/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/EditAccountJourneyServiceTests/SetAccountTypesShould.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/EditAccountJourneyServiceTests/SetAccountTypesShould.cs
@@ -15,7 +15,7 @@ public class SetAccountTypesShould : EditAccountJourneyServiceTestBase
         var originalAccount = AccountBuilder.Build();
 
         var updatedAccount = AccountBuilder.Build();
-        var editedAccountTypes = new EditAccountJourneyModel(updatedAccount).AccountTypes!;
+        var editedAccountTypes = new EditAccountJourneyModel(updatedAccount).AccountDetails.Types ?? new List<AccountType>();
 
         MockAccountService
             .Setup(x => x.GetByIdAsync(originalAccount.Id))
@@ -31,7 +31,7 @@ public class SetAccountTypesShould : EditAccountJourneyServiceTestBase
         );
 
         editAccountJourneyModel.Should().NotBeNull();
-        editAccountJourneyModel!.AccountTypes.Should().BeEquivalentTo(editedAccountTypes);
+        editAccountJourneyModel!.AccountDetails.Types.Should().BeEquivalentTo(editedAccountTypes);
 
         MockAccountService.Verify(x => x.GetByIdAsync(originalAccount.Id), Times.Once);
         VerifyAllNoOtherCall();

--- a/apps/user-management/apps/frontend/Models/EditAccountJourneyModel.cs
+++ b/apps/user-management/apps/frontend/Models/EditAccountJourneyModel.cs
@@ -6,7 +6,6 @@ public class EditAccountJourneyModel(Account account)
 {
     public Account Account { get; } = account;
 
-    public ImmutableList<AccountType>? AccountTypes { get; set; } = account.Types;
     public AccountStatus? AccountStatus { get; set; } = account.Status;
 
     public AccountDetails AccountDetails { get; set; } =

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EditAccountDetails.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EditAccountDetails.cshtml
@@ -1,4 +1,7 @@
 ﻿@page "{id:Guid}"
+@using Dfe.Sww.Ecf.Frontend.Models
+@using GovUk.Frontend.AspNetCore.TagHelpers
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts.EditAccountDetails
 
 @{

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EditAccountDetails.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EditAccountDetails.cshtml
@@ -36,7 +36,7 @@
 
                 @if (Model.ShowSweInput)
                 {
-                    <govuk-input for="SocialWorkEnglandNumber" spellcheck="false" type="number" input-class="govuk-!-width-one-third">
+                    <govuk-input for="SocialWorkEnglandNumber" spellcheck="false" input-class="govuk-input--width-10">
                         <govuk-input-label class="govuk-label">Social Work England registration number</govuk-input-label>
                         <govuk-input-hint>For example, SW1234</govuk-input-hint>
                         <govuk-input-error-message/>

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EditAccountDetails.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EditAccountDetails.cshtml
@@ -1,7 +1,4 @@
 ﻿@page "{id:Guid}"
-@using Dfe.Sww.Ecf.Frontend.Models
-@using GovUk.Frontend.AspNetCore.TagHelpers
-@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model Dfe.Sww.Ecf.Frontend.Pages.ManageAccounts.EditAccountDetails
 
 @{

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/EditAccountDetails.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/EditAccountDetails.cshtml.cs
@@ -63,9 +63,8 @@ public class EditAccountDetails(
         );
         SocialWorkEnglandNumber = isSwe ? swe?.GetNumber().ToString() : null;
 
-        var accountTypes = await editAccountJourneyService.GetAccountTypesAsync(id);
+        var accountTypes = accountDetails.Types;
         ShowSweInput = (accountTypes?.Contains(AccountType.EarlyCareerSocialWorker) ?? false) || (accountTypes?.Contains(AccountType.Assessor) ?? false);
-
         return Page();
     }
 
@@ -87,6 +86,9 @@ public class EditAccountDetails(
         accountDetails.LastName = LastName;
         accountDetails.Email = Email;
         accountDetails.SocialWorkEnglandNumber = SocialWorkEnglandNumber;
+
+        var accountTypes = accountDetails.Types;
+        ShowSweInput = (accountTypes?.Contains(AccountType.EarlyCareerSocialWorker) ?? false) || (accountTypes?.Contains(AccountType.Assessor) ?? false);
 
         var result = await validator.ValidateAsync(accountDetails);
         if (!result.IsValid)

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml
@@ -1,4 +1,4 @@
-﻿@page
+﻿@page "{id:Guid?}"
 @using Dfe.Sww.Ecf.Frontend.Models
 @model SelectUseCase
 @{

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml
@@ -8,7 +8,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <form method="post">
+        <form method="post" asp-page-handler="@(Model.Id is not null ? "Change" : "")">
             <div class="govuk-form-group">
 
                 <govuk-checkboxes for="SelectedAccountTypes">

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml
@@ -1,4 +1,4 @@
-﻿@page "{id:Guid?}"
+﻿@page
 @using Dfe.Sww.Ecf.Frontend.Models
 @model SelectUseCase
 @{
@@ -8,7 +8,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-        <form method="post" asp-page-handler="@(Model.Id is not null ? "Change" : "")">
+        <form method="post">
             <div class="govuk-form-group">
 
                 <govuk-checkboxes for="SelectedAccountTypes">

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml.cs
@@ -89,24 +89,15 @@ public class SelectUseCase(
 
         if (SelectedAccountTypes is [AccountType.Coordinator] && accountDetails?.SocialWorkEnglandNumber is not null)
         {
-            var updatedAccountDetails = new AccountDetails
-            {
-                FirstName = accountDetails.FirstName,
-                LastName = accountDetails.LastName,
-                MiddleNames = accountDetails.MiddleNames,
-                Email = accountDetails.Email,
-                SocialWorkEnglandNumber = null,
-                IsStaff = accountDetails.IsStaff,
-                Types = accountDetails.Types
-            };
+            accountDetails.SocialWorkEnglandNumber = null;
 
             if (id is null)
             {
-                createAccountJourneyService.SetAccountDetails(updatedAccountDetails);
+                createAccountJourneyService.SetAccountDetails(accountDetails);
             }
             else
             {
-                await editAccountJourneyService.SetAccountDetailsAsync(id.Value, updatedAccountDetails);
+                await editAccountJourneyService.SetAccountDetailsAsync(id.Value, accountDetails);
             }
 
             return false;

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml.cs
@@ -56,14 +56,14 @@ public class SelectUseCase(
 
         if (Id.HasValue)
         {
-            return await OnPostUpdateAsync(captureSocialWorkEnglandNumber);
+            return await OnPostUpdateAsync(Id.Value, captureSocialWorkEnglandNumber);
         }
 
         createAccountJourneyService.SetAccountTypes(SelectedAccountTypes);
         return Redirect(FromChangeLink && !captureSocialWorkEnglandNumber ? linkGenerator.ConfirmAccountDetails() : linkGenerator.AddAccountDetails());
     }
 
-    private async Task<IActionResult> OnPostUpdateAsync(bool captureSocialWorkEnglandNumber)
+    private async Task<IActionResult> OnPostUpdateAsync(Guid id, bool captureSocialWorkEnglandNumber)
     {
         if (Id.HasValue == false || SelectedAccountTypes == null)
         {

--- a/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageAccounts/SelectUseCase.cshtml.cs
@@ -83,18 +83,11 @@ public class SelectUseCase(
 
     private async Task<bool> ClearOrMarkForCaptureSocialWorkEnglandNumberAsync(Guid? id)
     {
-        var accountDetails = new AccountDetails();
-        if (id is null)
-        {
-            accountDetails = createAccountJourneyService.GetAccountDetails();
-        }
-        else
-        {
-            accountDetails = await editAccountJourneyService.GetAccountDetailsAsync((Guid)id);
-        }
+        var accountDetails = id is null
+            ? createAccountJourneyService.GetAccountDetails()
+            : await editAccountJourneyService.GetAccountDetailsAsync(id.Value);
 
-        if (SelectedAccountTypes?.Count == 1 && SelectedAccountTypes[0] == AccountType.Coordinator
-                                             && accountDetails is not null && accountDetails.SocialWorkEnglandNumber is not null)
+        if (SelectedAccountTypes is [AccountType.Coordinator] && accountDetails?.SocialWorkEnglandNumber is not null)
         {
             var updatedAccountDetails = new AccountDetails
             {
@@ -113,13 +106,13 @@ public class SelectUseCase(
             }
             else
             {
-                await editAccountJourneyService.SetAccountDetailsAsync((Guid)id, updatedAccountDetails);
+                await editAccountJourneyService.SetAccountDetailsAsync(id.Value, updatedAccountDetails);
             }
 
             return false;
         }
 
         return SelectedAccountTypes?.Contains(AccountType.Assessor) == true
-               && accountDetails is not null && accountDetails.SocialWorkEnglandNumber is null;
+               && accountDetails?.SocialWorkEnglandNumber is null;
     }
 }

--- a/apps/user-management/apps/frontend/Services/Journeys/EditAccountJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/EditAccountJourneyService.cs
@@ -43,6 +43,7 @@ public class EditAccountJourneyService(
         }
 
         editAccountJourneyModel = new EditAccountJourneyModel(account);
+        SetEditAccountJourneyModel(accountId, editAccountJourneyModel);
         return editAccountJourneyModel;
     }
 
@@ -51,16 +52,15 @@ public class EditAccountJourneyService(
         return await GetEditAccountJourneyModelAsync(accountId) is not null;
     }
 
-    public async Task<ImmutableList<AccountType>?> GetAccountTypesAsync(Guid accountId)
+    public async Task<IList<AccountType>?> GetAccountTypesAsync(Guid accountId)
     {
         var editAccountJourneyModel = await GetEditAccountJourneyModelAsync(accountId);
-        return editAccountJourneyModel?.AccountTypes;
+        return editAccountJourneyModel?.AccountDetails.Types;
     }
 
     public async Task<AccountDetails?> GetAccountDetailsAsync(Guid accountId)
     {
         var editAccountJourneyModel = await GetEditAccountJourneyModelAsync(accountId);
-        SetEditAccountJourneyModel(accountId, editAccountJourneyModel);
         return editAccountJourneyModel?.AccountDetails;
     }
 
@@ -84,7 +84,7 @@ public class EditAccountJourneyService(
         var editAccountJourneyModel =
             await GetEditAccountJourneyModelAsync(accountId)
             ?? throw AccountNotFoundException(accountId);
-        editAccountJourneyModel.AccountTypes = accountTypes.ToImmutableList();
+        editAccountJourneyModel.AccountDetails.Types = accountTypes.ToImmutableList();
         SetEditAccountJourneyModel(accountId, editAccountJourneyModel);
     }
 

--- a/apps/user-management/apps/frontend/Services/Journeys/EditAccountJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/EditAccountJourneyService.cs
@@ -60,6 +60,7 @@ public class EditAccountJourneyService(
     public async Task<AccountDetails?> GetAccountDetailsAsync(Guid accountId)
     {
         var editAccountJourneyModel = await GetEditAccountJourneyModelAsync(accountId);
+        SetEditAccountJourneyModel(accountId, editAccountJourneyModel);
         return editAccountJourneyModel?.AccountDetails;
     }
 

--- a/apps/user-management/apps/frontend/Services/Journeys/Interfaces/IEditAccountJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/Interfaces/IEditAccountJourneyService.cs
@@ -6,7 +6,7 @@ namespace Dfe.Sww.Ecf.Frontend.Services.Journeys.Interfaces;
 public interface IEditAccountJourneyService
 {
     Task<bool> IsAccountIdValidAsync(Guid accountId);
-    Task<ImmutableList<AccountType>?> GetAccountTypesAsync(Guid accountId);
+    Task<IList<AccountType>?> GetAccountTypesAsync(Guid accountId);
     Task<AccountDetails?> GetAccountDetailsAsync(Guid accountId);
     Task<bool?> GetIsStaffAsync(Guid accountId);
     Task SetAccountDetailsAsync(Guid accountId, AccountDetails accountDetails);


### PR DESCRIPTION
Changes for [SWIP-818](https://dfedigital.atlassian.net/browse/SWIP-818) including:
- logic to clear the SWE number when changing existing user account type from Assessor to Coordinator
- logic to capture the SWE number when account type change includes Assessor
- appropriate redirects for the logic above
- edit account details form changes to align with add account details
- storing account details in session as early as possible to avoid unnecessary database calls
- unit tests

[SWIP-818]: https://dfedigital.atlassian.net/browse/SWIP-818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ