### PR TITLE
SWIP-881 Enter local authority page

### DIFF
--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/DashboardTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/DashboardTests.cs
@@ -17,7 +17,7 @@ public class DashboardTests : PageModelTestBase<Dashboard>
         Sut.PageContext.HttpContext = HttpContext;
     }
 
-    private Dashboard Sut { get; } = new();
+    private Dashboard Sut { get; } = new(new FakeLinkGenerator());
 
     [Fact]
     public void OnGet_WhenCalled_LoadsPage()

--- a/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageOrganisations/ManageOrganisationsPageTestBase.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Pages/ManageOrganisations/ManageOrganisationsPageTestBase.cs
@@ -1,4 +1,5 @@
 using Dfe.Sww.Ecf.Frontend.Services.Interfaces;
+using Dfe.Sww.Ecf.Frontend.Services.Journeys.Interfaces;
 using Dfe.Sww.Ecf.Frontend.Test.UnitTests.Helpers.Builders;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -13,15 +14,20 @@ public abstract class ManageOrganisationsPageTestBase<[MeansTestSubject] T> : Pa
 
     private protected Mock<IOrganisationService> MockOrganisationService { get; }
 
+    private protected Mock<ICreateOrganisationJourneyService> MockCreateOrganisationJourneyService { get; }
+
     protected ManageOrganisationsPageTestBase()
     {
         OrganisationBuilder = new();
 
         MockOrganisationService = new();
+
+        MockCreateOrganisationJourneyService = new();
     }
 
     private protected void VerifyAllNoOtherCalls()
     {
         MockOrganisationService.VerifyNoOtherCalls();
+        MockCreateOrganisationJourneyService.VerifyNoOtherCalls();
     }
 }

--- a/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/CreateOrganisationJourneyServiceTests/GetLocalAuthorityCodeShould.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/CreateOrganisationJourneyServiceTests/GetLocalAuthorityCodeShould.cs
@@ -1,0 +1,39 @@
+using Bogus;
+using Dfe.Sww.Ecf.Frontend.Extensions;
+using Dfe.Sww.Ecf.Frontend.Models.ManageOrganisation;
+using FluentAssertions;
+using OpenIddict.Client.WebIntegration;
+using Xunit;
+
+namespace Dfe.Sww.Ecf.Frontend.Test.UnitTests.Services.JourneyTests.CreateOrganisationJourneyServiceTests;
+
+public class GetLocalAuthorityCodeShould : CreateOrganisationJourneyServiceTestBase
+{
+    [Fact]
+    public void WhenCalled_WithExistingSessionData_ReturnsLocalAuthorityCode()
+    {
+        // Arrange
+        var expectedLocalAuthorityCode = new Faker().Random.Int();
+        HttpContext.Session.Set(
+            CreateOrganisationSessionKey,
+            new CreateOrganisationJourneyModel { LocalAuthorityCode = expectedLocalAuthorityCode }
+        );
+
+        // Act
+        var response = Sut.GetLocalAuthorityCode();
+
+        // Assert
+        response.Should().NotBeNull();
+        response.Should().Be(expectedLocalAuthorityCode);
+    }
+
+    [Fact]
+    public void WhenCalled_WithBlankSession_ReturnsNull()
+    {
+        // Act
+        var response = Sut.GetLocalAuthorityCode();
+
+        // Assert
+        response.Should().BeNull();
+    }
+}

--- a/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/CreateOrganisationJourneyServiceTests/ResetCreateAccountJourneyModelShould.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/CreateOrganisationJourneyServiceTests/ResetCreateAccountJourneyModelShould.cs
@@ -1,5 +1,4 @@
 ﻿using Dfe.Sww.Ecf.Frontend.Extensions;
-using Dfe.Sww.Ecf.Frontend.Models;
 using Dfe.Sww.Ecf.Frontend.Models.ManageOrganisation;
 using FluentAssertions;
 using Xunit;

--- a/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/CreateOrganisationJourneyServiceTests/SetLocalAuthorityCodeShould.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/CreateOrganisationJourneyServiceTests/SetLocalAuthorityCodeShould.cs
@@ -1,0 +1,53 @@
+using Bogus;
+using Dfe.Sww.Ecf.Frontend.Extensions;
+using Dfe.Sww.Ecf.Frontend.Models.ManageOrganisation;
+using FluentAssertions;
+using OpenIddict.Client.WebIntegration;
+using Xunit;
+
+namespace Dfe.Sww.Ecf.Frontend.Test.UnitTests.Services.JourneyTests.CreateOrganisationJourneyServiceTests;
+
+public class SetLocalAuthorityCodeShould : CreateOrganisationJourneyServiceTestBase
+{
+    [Fact]
+    public void WhenCalled_WithExistingSessionData_SetsLocalAuthorityCode()
+    {
+        // Arrange
+        var expectedLocalAuthorityCode = new Faker().Random.Int();
+        HttpContext.Session.Set(
+            CreateOrganisationSessionKey,
+            new CreateOrganisationJourneyModel { LocalAuthorityCode = new Faker().Random.Int() }
+        );
+
+        // Act
+        Sut.SetLocalAuthorityCode(expectedLocalAuthorityCode);
+
+        // Assert
+        HttpContext.Session.TryGet(
+            CreateOrganisationSessionKey,
+            out CreateOrganisationJourneyModel? createOrganisationJourneyModel
+        );
+
+        createOrganisationJourneyModel.Should().NotBeNull();
+        createOrganisationJourneyModel!.LocalAuthorityCode.Should().Be(expectedLocalAuthorityCode);
+    }
+
+    [Fact]
+    public void WhenCalled_WithBlankSession_SetsLocalAuthorityCode()
+    {
+        // Arrange
+        var expectedLocalAuthorityCode = new Faker().Random.Int();
+
+        // Act
+        Sut.SetLocalAuthorityCode(expectedLocalAuthorityCode);
+
+        // Assert
+        HttpContext.Session.TryGet(
+            CreateOrganisationSessionKey,
+            out CreateOrganisationJourneyModel? createOrganisationJourneyModel
+        );
+
+        createOrganisationJourneyModel.Should().NotBeNull();
+        createOrganisationJourneyModel!.LocalAuthorityCode.Should().Be(expectedLocalAuthorityCode);
+    }
+}

--- a/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/CreateOrganisationJourneyServiceTests/SetOrganisationShould.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/Services/JourneyTests/CreateOrganisationJourneyServiceTests/SetOrganisationShould.cs
@@ -1,0 +1,52 @@
+using Dfe.Sww.Ecf.Frontend.Extensions;
+using Dfe.Sww.Ecf.Frontend.Models.ManageOrganisation;
+using FluentAssertions;
+using Xunit;
+
+namespace Dfe.Sww.Ecf.Frontend.Test.UnitTests.Services.JourneyTests.CreateOrganisationJourneyServiceTests;
+
+public class SetOrganisationShould : CreateOrganisationJourneyServiceTestBase
+{
+    [Fact]
+    public void WhenCalled_WithExistingSessionData_SetsOrganisation()
+    {
+        // Arrange
+        var expectedOrganisation = OrganisationBuilder.Build();
+        var existingOrganisation = OrganisationBuilder.Build();
+        HttpContext.Session.Set(
+            CreateOrganisationSessionKey,
+            new CreateOrganisationJourneyModel { Organisation = existingOrganisation }
+        );
+
+        // Act
+        Sut.SetOrganisation(expectedOrganisation);
+
+        // Assert
+        HttpContext.Session.TryGet(
+            CreateOrganisationSessionKey,
+            out CreateOrganisationJourneyModel? createOrganisationJourneyModel
+        );
+
+        createOrganisationJourneyModel.Should().NotBeNull();
+        createOrganisationJourneyModel!.Organisation.Should().BeEquivalentTo(expectedOrganisation);
+    }
+
+    [Fact]
+    public void WhenCalled_WithBlankSession_SetsOrganisation()
+    {
+        // Arrange
+        var expectedOrganisation = OrganisationBuilder.Build();
+
+        // Act
+        Sut.SetOrganisation(expectedOrganisation);
+
+        // Assert
+        HttpContext.Session.TryGet(
+            CreateOrganisationSessionKey,
+            out CreateOrganisationJourneyModel? createOrganisationJourneyModel
+        );
+
+        createOrganisationJourneyModel.Should().NotBeNull();
+        createOrganisationJourneyModel!.Organisation.Should().BeEquivalentTo(expectedOrganisation);
+    }
+}

--- a/apps/user-management/apps/frontend/Pages/Dashboard.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/Dashboard.cshtml.cs
@@ -1,12 +1,13 @@
 using Dfe.Sww.Ecf.Frontend.Authorisation;
 using Dfe.Sww.Ecf.Frontend.Models.ManageOrganisations;
 using Dfe.Sww.Ecf.Frontend.Pages.Shared;
+using Dfe.Sww.Ecf.Frontend.Routing;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace Dfe.Sww.Ecf.Frontend.Pages;
 
 [AuthorizeRoles(RoleType.Administrator)]
-public class Dashboard : BasePageModel
+public class Dashboard(EcfLinkGenerator linkGenerator) : BasePageModel
 {
     public IEnumerable<CardItem>? Items { get; set; }
 
@@ -19,7 +20,7 @@ public class Dashboard : BasePageModel
                 Link = new CardLink
                 {
                     Text = "Manage organisations",
-                    Path = "/manage-organisations", // TODO replace with path to manage organisations page when built via link generator
+                    Path = linkGenerator.ManageOrganisations()
                 },
                 Description = "Add or edit organisations and manage users."
             }

--- a/apps/user-management/apps/frontend/Pages/ManageOrganisations/EnterLocalAuthorityCode.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageOrganisations/EnterLocalAuthorityCode.cshtml
@@ -1,0 +1,20 @@
+@page
+@model EnterLocalAuthorityCode
+
+@{
+    Model.Title = "What is the local authority code?";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form method="post">
+            <govuk-input for="LocalAuthorityCode" input-class="govuk-!-width-two-thirds">
+                <govuk-input-label is-page-heading="true" class="govuk-label--l">What is the local authority code?</govuk-input-label>
+                <govuk-input-hint>Enter the local authority code (LA code) in full</govuk-input-hint>
+                <govuk-input-error-message/>
+            </govuk-input>
+
+            <button type="submit" class="govuk-button">Continue</button>
+        </form>
+    </div>
+</div>

--- a/apps/user-management/apps/frontend/Pages/ManageOrganisations/EnterLocalAuthorityCode.cshtml.cs
+++ b/apps/user-management/apps/frontend/Pages/ManageOrganisations/EnterLocalAuthorityCode.cshtml.cs
@@ -1,0 +1,57 @@
+using Dfe.Sww.Ecf.Frontend.Authorisation;
+using Dfe.Sww.Ecf.Frontend.Extensions;
+using Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Models.Pagination;
+using Dfe.Sww.Ecf.Frontend.Models.ManageOrganisation;
+using Dfe.Sww.Ecf.Frontend.Pages.Shared;
+using Dfe.Sww.Ecf.Frontend.Routing;
+using Dfe.Sww.Ecf.Frontend.Services.Interfaces;
+using Dfe.Sww.Ecf.Frontend.Services.Journeys.Interfaces;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Dfe.Sww.Ecf.Frontend.Pages.ManageOrganisations;
+
+[AuthorizeRoles(RoleType.Administrator)]
+public class EnterLocalAuthorityCode(
+    ICreateOrganisationJourneyService createOrganisationJourneyService,
+    IOrganisationService organisationService,
+    EcfLinkGenerator linkGenerator,
+    IValidator<EnterLocalAuthorityCode> validator
+    ) : BasePageModel
+{
+    [BindProperty]
+    public int? LocalAuthorityCode { get; set; }
+
+    public PageResult OnGet()
+    {
+        var localAuthorityCode = createOrganisationJourneyService.GetLocalAuthorityCode();
+        if (localAuthorityCode is not null)
+        {
+            LocalAuthorityCode = localAuthorityCode;
+        }
+
+        BackLinkPath = linkGenerator.ManageOrganisations();
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPostAsync()
+    {
+        var result = await validator.ValidateAsync(this);
+        if (!result.IsValid)
+        {
+            result.AddToModelState(ModelState);
+            BackLinkPath = linkGenerator.ManageOrganisations();
+            return Page();
+        }
+
+        createOrganisationJourneyService.SetLocalAuthorityCode(LocalAuthorityCode);
+
+        var organisation = organisationService.GetByLocalAuthorityCode(LocalAuthorityCode);
+        // TODO show error if organisation not found once validation and error message designs are available
+        createOrganisationJourneyService.SetOrganisation(organisation);
+
+        // TODO redirect to confirm page once built
+        return Redirect(linkGenerator.ManageOrganisations());
+    }
+}

--- a/apps/user-management/apps/frontend/Pages/ManageOrganisations/Index.cshtml
+++ b/apps/user-management/apps/frontend/Pages/ManageOrganisations/Index.cshtml
@@ -19,8 +19,7 @@
             <p class="govuk-body">You have not added any organisations yet.</p>
         }
 
-        @* TODO update href when page is added *@
-        <govuk-button-link href="@LinkGenerator.AddSomeoneNew()">Add new organisation</govuk-button-link>
+        <govuk-button-link href="@LinkGenerator.EnterLocalAuthorityCode()">Add new organisation</govuk-button-link>
 
         @if (Model.Organisations?.Any() == true)
         {
@@ -55,8 +54,7 @@
                             <p class="govuk-body">@account.Type?.GetDisplayName()</p>
                         </td>
                         <td class="govuk-table__cell">
-                            @* TODO update asp-page when page is added *@
-                            <a title="Manage Users" class="govuk-link govuk-link--no-visited-state" asp-page="index">Manage users</a>
+                            <a title="Manage Users" class="govuk-link govuk-link--no-visited-state" asp-page="EnterLocalAuthorityCode">Manage users</a>
                         </td>
                     </tr>
                 }

--- a/apps/user-management/apps/frontend/Pages/Shared/_AuthenticatedHeader.cshtml
+++ b/apps/user-management/apps/frontend/Pages/Shared/_AuthenticatedHeader.cshtml
@@ -123,7 +123,7 @@
                                 if (Context.User.Identity?.IsAuthenticated == true)
                                 {
                                     <header-link is-active-class="@Html.IsActive("/Dashboard")" href="@LinkGenerator.Dashboard()" text="Dashboard" is-visible="@User.IsInRole(RoleType.Administrator.ToString())"></header-link>
-                                    <header-link is-active-class="@Html.IsActive("/ManageOrganisations")" href="@LinkGenerator.Dashboard()" text="Manage organisations" is-visible="@User.IsInRole(RoleType.Administrator.ToString())"></header-link> // TODO update href with correct method once page is built
+                                    <header-link is-active-class="@Html.IsActive("/ManageOrganisations")" href="@LinkGenerator.ManageOrganisations()" text="Manage organisations" is-visible="@User.IsInRole(RoleType.Administrator.ToString())"></header-link>
                                     <header-link is-active-class="@Html.IsActive("/Index")" href="@LinkGenerator.Home()" text="Home" is-visible="@User.IsInRole(RoleType.Coordinator.ToString())"></header-link>
                                     <header-link is-active-class="@Html.IsActive("/ManageAccounts")" href="@LinkGenerator.ManageAccounts()" text="Manage users" is-visible="@User.IsInRole(RoleType.Coordinator.ToString())"></header-link>
                                 }

--- a/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
+++ b/apps/user-management/apps/frontend/Routing/EcfLinkGenerator.cs
@@ -93,7 +93,6 @@ public abstract class EcfLinkGenerator(
     public string ViewAccountDetails(Guid id) => GetRequiredPathByPage("/ManageAccounts/ViewAccountDetails", routeValues: new { id });
     public string SelectAccountType() => GetRequiredPathByPage("/ManageAccounts/SelectAccountType");
     public string SelectAccountTypeChange() => GetRequiredPathByPage("/ManageAccounts/SelectAccountType", handler: "Change");
-
     public string AddSomeoneNew() => GetRequiredPathByPage("/ManageAccounts/SelectAccountType", handler: "New");
     public string SelectUseCase() => GetRequiredPathByPage("/ManageAccounts/SelectUseCase");
     public string SelectUseCaseChange(Guid? id = null) => GetRequiredPathByPage("/ManageAccounts/SelectUseCase", handler: "Change", routeValues: new { id });
@@ -153,6 +152,7 @@ public abstract class EcfLinkGenerator(
 
     // Manage organisations links
     public string ManageOrganisations(int? offset = 0, int? pageSize = 10) => GetRequiredPathByPage("/ManageOrganisations/Index", routeValues: new { offset, pageSize });
+    public string EnterLocalAuthorityCode() => GetRequiredPathByPage("/ManageOrganisations/EnterLocalAuthorityCode");
 
     protected abstract string GetRequiredPathByPage(
         string page,

--- a/apps/user-management/apps/frontend/Services/Interfaces/IOrganisationService.cs
+++ b/apps/user-management/apps/frontend/Services/Interfaces/IOrganisationService.cs
@@ -6,4 +6,5 @@ namespace Dfe.Sww.Ecf.Frontend.Services.Interfaces;
 public interface IOrganisationService
 {
     public Task<PaginationResult<Organisation>> GetAllAsync(PaginationRequest request);
+    public Organisation GetByLocalAuthorityCode(int? localAuthorityCode);
 }

--- a/apps/user-management/apps/frontend/Services/Journeys/CreateOrganisationJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/CreateOrganisationJourneyService.cs
@@ -40,6 +40,13 @@ public class CreateOrganisationJourneyService(IHttpContextAccessor httpContextAc
         SetCreateOrganisationJourneyModel(createOrganisationJourneyModel);
     }
 
+    public void SetOrganisation(Organisation organisation)
+    {
+        var createOrganisationJourneyModel = GetOrganisationJourneyModel();
+        createOrganisationJourneyModel.Organisation = organisation;
+        SetCreateOrganisationJourneyModel(createOrganisationJourneyModel);
+    }
+
     public void ResetCreateOrganisationJourneyModel()
     {
         Session.Remove(CreateOrganisationSessionKey);

--- a/apps/user-management/apps/frontend/Services/Journeys/Interfaces/ICreateOrganisationJourneyService.cs
+++ b/apps/user-management/apps/frontend/Services/Journeys/Interfaces/ICreateOrganisationJourneyService.cs
@@ -6,5 +6,6 @@ public interface ICreateOrganisationJourneyService
 {
     int? GetLocalAuthorityCode();
     void SetLocalAuthorityCode(int? localAuthorityCode);
+    void SetOrganisation(Organisation organisation);
     void ResetCreateOrganisationJourneyModel();
 }

--- a/apps/user-management/apps/frontend/Services/OrganisationService.cs
+++ b/apps/user-management/apps/frontend/Services/OrganisationService.cs
@@ -24,4 +24,17 @@ public class OrganisationService(
 
         return organisations;
     }
+
+    // TODO Get from database when data is available
+    public Organisation GetByLocalAuthorityCode(int? localAuthorityCode)
+    {
+        return new Organisation
+        {
+            OrganisationId = new Guid(),
+            LocalAuthorityCode = localAuthorityCode,
+            OrganisationName = "Test Organisation",
+            Type = OrganisationType.LocalAuthority,
+            Region = "Test Region"
+        };
+    }
 }

--- a/apps/user-management/apps/frontend/Validation/ManageOrganisations/EnterLocalAuthorityCodeValidator.cs
+++ b/apps/user-management/apps/frontend/Validation/ManageOrganisations/EnterLocalAuthorityCodeValidator.cs
@@ -1,0 +1,15 @@
+using Dfe.Sww.Ecf.Frontend.Pages.ManageOrganisations;
+using FluentValidation;
+
+namespace Dfe.Sww.Ecf.Frontend.Validation.ManageOrganisations;
+
+public class EnterLocalAuthorityCodeValidator : AbstractValidator<EnterLocalAuthorityCode>
+{
+    public EnterLocalAuthorityCodeValidator()
+    {
+        // TODO update error message once design is revisited, and unit test for the page
+        RuleFor(model => model.LocalAuthorityCode)
+            .NotEmpty()
+            .WithMessage("Enter the local authority code (LA code) in full. (error message TBC)");
+    }
+}


### PR DESCRIPTION
Changes for [SWIP-881](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-881) including:
- creating the "EnterLocalAuthorityCode" page, getting and setting the LA code in the journey session 
- stubbed method for organisation service to get a test organisation by LA code
- setting the retrieved test organisation in the journey for use on the check details page to be built
- validation for empty LA code (temporary message for now)
- updating the index page to link to the "EnterLocalAuthorityCode" page
- updating the dashboard page and top nav to link to the index page
- unit tests