### PR TITLE
SWP-939 - Set correct functions in ws setup script

### DIFF
--- a/scripts/setup_moodle_webservice.php
+++ b/scripts/setup_moodle_webservice.php
@@ -193,8 +193,7 @@ if (!$token) {
 
 // List of Moodle web service functions you want to allow
 $functions = [
-#    'core_user_get_users',
-    'core_course_get_courses',
+    'core_user_create_users',
 ];
 
 foreach ($functions as $functionname) {


### PR DESCRIPTION
Currently, we are only using the `core_user_create_users` in our frontend integration so updated the script to match.

We'll need to make sure this script gets updated whenever we need to support extra functions.