### PR TITLE
SWIP-939 - Setup notifications service and networking

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -139,6 +139,7 @@ jobs:
             -var='basic_auth_password_team_environments=${{ secrets.BASIC_AUTH_PASSWORD_TEAM_ENVIRONMENTS }}' \
             -var='basic_auth_password_user_environments=${{ secrets.BASIC_AUTH_PASSWORD_USER_ENVIRONMENTS }}' \
             -var='email_support_address=${{ vars.EMAIL_SUPPORT_ADDRESS }}' \
+            -var='govnotify_api_key=${{secrets.GOVNOTIFY_API_KEY}}' \
             || export exitcode=$?
 
           echo "exitcode=$exitcode" >> $GITHUB_OUTPUT
@@ -154,5 +155,4 @@ jobs:
         if: ${{ inputs.action == 'Plan & Apply' }}
         env:
           TF_VAR_moodle_admin_password: ${{ secrets.MOODLE_ADMIN_PASSWORD }}
-          TF_VAR_govnotify_api_key: ${{secrets.GOVNOTIFY_API_KEY}}
         run: terraform apply -auto-approve tfplan

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -154,4 +154,5 @@ jobs:
         if: ${{ inputs.action == 'Plan & Apply' }}
         env:
           TF_VAR_moodle_admin_password: ${{ secrets.MOODLE_ADMIN_PASSWORD }}
+          TF_VAR_govnotify_api_key: ${{secrets.GOVNOTIFY_API_KEY}}
         run: terraform apply -auto-approve tfplan

--- a/terraform/modules/environment-stack/network.tf
+++ b/terraform/modules/environment-stack/network.tf
@@ -6,3 +6,28 @@ resource "azurerm_virtual_network" "vnet_stack" {
 
   tags = var.tags
 }
+
+
+resource "azurerm_network_security_group" "funcapp_nsg" {
+  name                = "${var.resource_name_prefix}-nsg-funcapp"
+  location            = var.location
+  resource_group_name = azurerm_resource_group.rg_primary.name
+  tags                = var.tags
+
+  security_rule {
+    name                       = "${var.resource_name_prefix}-allow-services"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = azurerm_subnet.sn_service_apps.address_prefixes[0]
+    destination_address_prefix = azurerm_subnet.sn_function_app.address_prefixes[0]
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "funcapp_nsg_assoc" {
+  subnet_id                 = azurerm_subnet.sn_function_app.id
+  network_security_group_id = azurerm_network_security_group.funcapp_nsg.id
+}

--- a/terraform/modules/function-app/function-app.tf
+++ b/terraform/modules/function-app/function-app.tf
@@ -69,3 +69,25 @@ resource "azurerm_role_assignment" "acr_pull" {
   principal_type       = "ServicePrincipal"
   principal_id         = azurerm_linux_function_app.function_app.identity.0.principal_id
 }
+
+resource "azurerm_key_vault_access_policy" "kv_policy" {
+  key_vault_id = var.key_vault_id
+  tenant_id    = azurerm_linux_function_app.function_app.identity.0.tenant_id
+  object_id    = azurerm_linux_function_app.function_app.identity.0.principal_id
+
+  key_permissions = [
+    "Get",
+    "List",
+    "UnwrapKey"
+  ]
+
+  secret_permissions = [
+    "Get",
+    "List",
+  ]
+
+  certificate_permissions = [
+    "Get",
+    "List",
+  ]
+}

--- a/terraform/modules/function-app/function-app.tf
+++ b/terraform/modules/function-app/function-app.tf
@@ -33,7 +33,7 @@ resource "azurerm_linux_function_app" "function_app" {
 
   }
 
-  app_settings = {
+  app_settings = merge({
     "DOCKER_REGISTRY_SERVER_URL"            = "https://${var.acr_name}.azurecr.io"
     "APPLICATIONINSIGHTS_CONNECTION_STRING" = var.appinsights_connection_string
     "FUNCTIONS_WORKER_RUNTIME"              = "dotnet-isolated"
@@ -41,7 +41,7 @@ resource "azurerm_linux_function_app" "function_app" {
     "DOCKER_REGISTRY_SERVER_USERNAME"       = ""
     "DOCKER_REGISTRY_SERVER_PASSWORD"       = ""
     DOCKER_ENABLE_CI                        = "false" # Github will control CI, not Azure
-  }
+  }, var.app_settings)
 
 
   lifecycle {

--- a/terraform/modules/function-app/function-app.tf
+++ b/terraform/modules/function-app/function-app.tf
@@ -91,3 +91,8 @@ resource "azurerm_key_vault_access_policy" "kv_policy" {
     "List",
   ]
 }
+
+data "azurerm_function_app_host_keys" "function_keys" {
+  name                = azurerm_linux_function_app.function_app.name
+  resource_group_name = var.resource_group
+}

--- a/terraform/modules/function-app/network-integration.tf
+++ b/terraform/modules/function-app/network-integration.tf
@@ -19,14 +19,14 @@ resource "azurerm_private_dns_zone" "pvt_dns_zone" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "vnet_link" {
-  name                  = "${data.azurerm_virtual_network.main.name}-dns-link"
+  name                  = "${data.azurerm_virtual_network.vnet_stack.name}-dns-link"
   resource_group_name   = var.resource_group
   private_dns_zone_name = azurerm_private_dns_zone.pvt_dns_zone.name
   virtual_network_id    = var.virtual_network_id
 }
 
 resource "azurerm_private_endpoint" "function_app_endpoint" {
-  name                = "${data.azurerm_function_app.main.name}-endpoint"
+  name                = "${data.azurerm_function_app.function_app.name}-endpoint"
   location            = var.location
   resource_group_name = var.resource_group
   subnet_id           = var.subnet_functionapp_id
@@ -39,7 +39,7 @@ resource "azurerm_private_endpoint" "function_app_endpoint" {
 
   # Connect the endpoint to the Function App.
   private_service_connection {
-    name                           = "${data.azurerm_function_app.main.name}-connection"
+    name                           = "${data.azurerm_function_app.function_app.name}-connection"
     is_manual_connection           = false
     private_connection_resource_id = azurerm_linux_function_app.function_app.id
     subresource_names              = ["sites"]

--- a/terraform/modules/function-app/network-integration.tf
+++ b/terraform/modules/function-app/network-integration.tf
@@ -19,14 +19,14 @@ resource "azurerm_private_dns_zone" "pvt_dns_zone" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "vnet_link" {
-  name                  = "${data.azurerm_virtual_network.vnet_stack.name}-dns-link"
+  name                  = "${azurerm_virtual_network.vnet_stack.name}-dns-link"
   resource_group_name   = var.resource_group
   private_dns_zone_name = azurerm_private_dns_zone.pvt_dns_zone.name
   virtual_network_id    = var.virtual_network_id
 }
 
 resource "azurerm_private_endpoint" "function_app_endpoint" {
-  name                = "${data.azurerm_function_app.function_app.name}-endpoint"
+  name                = "${azurerm_linux_function_app.function_app.name}-endpoint"
   location            = var.location
   resource_group_name = var.resource_group
   subnet_id           = var.subnet_functionapp_id
@@ -39,7 +39,7 @@ resource "azurerm_private_endpoint" "function_app_endpoint" {
 
   # Connect the endpoint to the Function App.
   private_service_connection {
-    name                           = "${data.azurerm_function_app.function_app.name}-connection"
+    name                           = "${azurerm_linux_function_app.function_app.name}-connection"
     is_manual_connection           = false
     private_connection_resource_id = azurerm_linux_function_app.function_app.id
     subresource_names              = ["sites"]

--- a/terraform/modules/function-app/network-integration.tf
+++ b/terraform/modules/function-app/network-integration.tf
@@ -29,7 +29,7 @@ resource "azurerm_private_endpoint" "function_app_endpoint" {
   name                = "${azurerm_linux_function_app.function_app.name}-endpoint"
   location            = var.location
   resource_group_name = var.resource_group
-  subnet_id           = var.subnet_functionapp_id
+  subnet_id           = azurerm_subnet.private_endpoint.id
 
   # Create the necessary DNS 'A' record.
   private_dns_zone_group {

--- a/terraform/modules/function-app/network-integration.tf
+++ b/terraform/modules/function-app/network-integration.tf
@@ -19,7 +19,7 @@ resource "azurerm_private_dns_zone" "pvt_dns_zone" {
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "vnet_link" {
-  name                  = "${azurerm_virtual_network.vnet_stack.name}-dns-link"
+  name                  = "${var.virtual_network_name}-dns-link"
   resource_group_name   = var.resource_group
   private_dns_zone_name = azurerm_private_dns_zone.pvt_dns_zone.name
   virtual_network_id    = var.virtual_network_id

--- a/terraform/modules/function-app/network-integration.tf
+++ b/terraform/modules/function-app/network-integration.tf
@@ -2,3 +2,46 @@ resource "azurerm_app_service_virtual_network_swift_connection" "asvnsc_function
   app_service_id = azurerm_linux_function_app.function_app.id
   subnet_id      = var.subnet_functionapp_id
 }
+
+resource "azurerm_subnet" "private_endpoint" {
+  name                 = "endpoint-subnet"
+  resource_group_name  = var.resource_group
+  virtual_network_name = var.virtual_network_name
+  address_prefixes     = ["10.0.7.0/24"]
+
+  # This setting is required for private endpoint subnets.
+  private_endpoint_network_policies = "Disabled"
+}
+
+resource "azurerm_private_dns_zone" "pvt_dns_zone" {
+  name                = "privatelink.azurewebsites.net"
+  resource_group_name = var.resource_group
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "vnet_link" {
+  name                  = "${data.azurerm_virtual_network.main.name}-dns-link"
+  resource_group_name   = var.resource_group
+  private_dns_zone_name = azurerm_private_dns_zone.pvt_dns_zone.name
+  virtual_network_id    = var.virtual_network_id
+}
+
+resource "azurerm_private_endpoint" "function_app_endpoint" {
+  name                = "${data.azurerm_function_app.main.name}-endpoint"
+  location            = var.location
+  resource_group_name = var.resource_group
+  subnet_id           = var.subnet_functionapp_id
+
+  # Create the necessary DNS 'A' record.
+  private_dns_zone_group {
+    name                 = "default"
+    private_dns_zone_ids = [azurerm_private_dns_zone.pvt_dns_zone.id]
+  }
+
+  # Connect the endpoint to the Function App.
+  private_service_connection {
+    name                           = "${data.azurerm_function_app.main.name}-connection"
+    is_manual_connection           = false
+    private_connection_resource_id = azurerm_linux_function_app.function_app.id
+    subresource_names              = ["sites"]
+  }
+}

--- a/terraform/modules/function-app/outputs.tf
+++ b/terraform/modules/function-app/outputs.tf
@@ -7,3 +7,8 @@ output "function_app_private_url" {
   description = "The private endpoint URL of the function app"
   value       = "https://${azurerm_private_endpoint.function_app_endpoint.private_dns_zone_configs[0].record_sets[0].fqdn}"
 }
+
+output "function_app_key" {
+  description = "The default function key for the function app"
+  value       = azurerm_linux_function_app.function_app.default_key
+}

--- a/terraform/modules/function-app/outputs.tf
+++ b/terraform/modules/function-app/outputs.tf
@@ -10,5 +10,5 @@ output "function_app_private_url" {
 
 output "function_app_key" {
   description = "The default function key for the function app"
-  value       = azurerm_linux_function_app.function_app.default_key
+  value       = data.azurerm_function_app_host_keys.function_keys.default_function_key
 }

--- a/terraform/modules/function-app/outputs.tf
+++ b/terraform/modules/function-app/outputs.tf
@@ -1,0 +1,4 @@
+output "function_app_url" {
+  description = "The HTTPS URL of the function app"
+  value       = "https://${azurerm_linux_function_app.function_app.default_hostname}"
+}

--- a/terraform/modules/function-app/outputs.tf
+++ b/terraform/modules/function-app/outputs.tf
@@ -2,3 +2,8 @@ output "function_app_url" {
   description = "The HTTPS URL of the function app"
   value       = "https://${azurerm_linux_function_app.function_app.default_hostname}"
 }
+
+output "function_app_private_url" {
+  description = "The private endpoint URL of the function app"
+  value       = "https://${azurerm_private_endpoint.function_app_endpoint.private_dns_zone_configs[0].record_sets[0].fqdn}"
+}

--- a/terraform/modules/function-app/variables.tf
+++ b/terraform/modules/function-app/variables.tf
@@ -80,3 +80,9 @@ variable "subnet_functionapp_id" {
   description = "The ID of the function app subnet"
   type        = string
 }
+
+variable "app_settings" {
+  description = "App settings for the web app"
+  type        = map(string)
+}
+

--- a/terraform/modules/function-app/variables.tf
+++ b/terraform/modules/function-app/variables.tf
@@ -86,3 +86,12 @@ variable "app_settings" {
   type        = map(string)
 }
 
+variable "virtual_network_name" {
+  description = "The name of the main vnet"
+  type        = string
+}
+
+variable "virtual_network_id" {
+  description = "The ID of the main vnet"
+  type        = string
+}

--- a/terraform/modules/function-app/variables.tf
+++ b/terraform/modules/function-app/variables.tf
@@ -95,3 +95,8 @@ variable "virtual_network_id" {
   description = "The ID of the main vnet"
   type        = string
 }
+
+variable "key_vault_id" {
+  description = "ID of the Key Vault to grant access to"
+  type        = string
+}

--- a/terraform/notification-service.tf
+++ b/terraform/notification-service.tf
@@ -1,5 +1,5 @@
 resource "azurerm_key_vault_secret" "govnotify_api_key" {
-  name         = "GOVNOTIFY-API-KEY"
+  name         = "NotificationService-GovNotifyApiKey"
   value        = var.govnotify_api_key
   key_vault_id = module.stack.kv_id
 

--- a/terraform/notification-service.tf
+++ b/terraform/notification-service.tf
@@ -33,6 +33,7 @@ module "notification-service" {
   subnet_functionapp_id         = module.stack.subnet_functionapp_id
   virtual_network_name          = module.stack.vnet_name
   virtual_network_id            = module.stack.vnet_id
+  key_vault_id                  = module.stack.kv_id
 
   app_settings = merge({
     "GOVNOTIFY__APIKEY" = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.govnotify_api_key.name})"

--- a/terraform/notification-service.tf
+++ b/terraform/notification-service.tf
@@ -1,3 +1,13 @@
+resource "azurerm_key_vault_secret" "govnotify_api_key" {
+  name         = "GOVNOTIFY-API-KEY"
+  value        = var.govnotify_api_key
+  key_vault_id = module.stack.kv_id
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}
+
 module "notification-service" {
   source                        = "./modules/function-app"
   environment                   = var.environment
@@ -15,4 +25,8 @@ module "notification-service" {
   appinsights_connection_string = module.stack.appinsights_connection_string
   health_check_path             = "/api/health"
   subnet_functionapp_id         = module.stack.subnet_functionapp_id
+  
+  app_settings = merge({
+    "GOVNOTIFY__APIKEY" = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.govnotify_api_key.name})"
+  }, var.notification_service_app_settings)
 }

--- a/terraform/notification-service.tf
+++ b/terraform/notification-service.tf
@@ -7,6 +7,7 @@ resource "azurerm_key_vault_secret" "govnotify_api_key" {
   lifecycle {
     ignore_changes = [value]
   }
+  #checkov:skip=CKV_AZURE_41:No expiry date
 }
 
 resource "azurerm_key_vault_secret" "function_key" {
@@ -14,6 +15,7 @@ resource "azurerm_key_vault_secret" "function_key" {
   value        = module.notification-service.function_app_key
   key_vault_id = module.stack.kv_id
   content_type = "function app key"
+  #checkov:skip=CKV_AZURE_41:No expiry date
 }
 
 module "notification-service" {

--- a/terraform/notification-service.tf
+++ b/terraform/notification-service.tf
@@ -8,6 +8,12 @@ resource "azurerm_key_vault_secret" "govnotify_api_key" {
   }
 }
 
+resource "azurerm_key_vault_secret" "function_key" {
+  name         = "NotificationService-FunctionKey"
+  value        = module.notification-service.function_app_key
+  key_vault_id = module.stack.kv_id
+}
+
 module "notification-service" {
   source                        = "./modules/function-app"
   environment                   = var.environment

--- a/terraform/notification-service.tf
+++ b/terraform/notification-service.tf
@@ -25,6 +25,8 @@ module "notification-service" {
   appinsights_connection_string = module.stack.appinsights_connection_string
   health_check_path             = "/api/health"
   subnet_functionapp_id         = module.stack.subnet_functionapp_id
+  virtual_network_name          = module.stack.vnet_name
+  virtual_network_id            = module.stack.vnet_id
 
   app_settings = merge({
     "GOVNOTIFY__APIKEY" = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.govnotify_api_key.name})"

--- a/terraform/notification-service.tf
+++ b/terraform/notification-service.tf
@@ -2,6 +2,7 @@ resource "azurerm_key_vault_secret" "govnotify_api_key" {
   name         = "NotificationService-GovNotifyApiKey"
   value        = var.govnotify_api_key
   key_vault_id = module.stack.kv_id
+  content_type = "API Key"
 
   lifecycle {
     ignore_changes = [value]
@@ -12,6 +13,7 @@ resource "azurerm_key_vault_secret" "function_key" {
   name         = "NotificationService-FunctionKey"
   value        = module.notification-service.function_app_key
   key_vault_id = module.stack.kv_id
+  content_type = "function app key"
 }
 
 module "notification-service" {

--- a/terraform/notification-service.tf
+++ b/terraform/notification-service.tf
@@ -25,7 +25,7 @@ module "notification-service" {
   appinsights_connection_string = module.stack.appinsights_connection_string
   health_check_path             = "/api/health"
   subnet_functionapp_id         = module.stack.subnet_functionapp_id
-  
+
   app_settings = merge({
     "GOVNOTIFY__APIKEY" = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.govnotify_api_key.name})"
   }, var.notification_service_app_settings)

--- a/terraform/user-management.tf
+++ b/terraform/user-management.tf
@@ -36,7 +36,7 @@ module "user_management" {
     "AUTHCLIENTOPTIONS__BASEURL"              = module.auth_service.front_door_app_url
     "MOODLECLIENTOPTIONS__BASEURL"            = "${module.web_app_moodle["primary"].front_door_app_url}/webservice/rest/server.php"
     "MOODLECLIENTOPTIONS__APITOKEN"           = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.web_service_token.name})"
-    "NOTIFICATIONCLIENTOPTIONS__BASEURL"      = module.notification-service.function_app_private_url
+    "NOTIFICATIONCLIENTOPTIONS__BASEURL"      = module.notification-service.function_app_url
     "NOTIFICATIONCLIENTOPTIONS__FUNCTIONKEY"  = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.function_key.name})"
     "BASIC_AUTH_USER"                         = var.basic_auth_user
     "BASIC_AUTH_PASSWORD"                     = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/Sites-BasicAuthPassword)"

--- a/terraform/user-management.tf
+++ b/terraform/user-management.tf
@@ -36,7 +36,7 @@ module "user_management" {
     "AUTHCLIENTOPTIONS__BASEURL"              = module.auth_service.front_door_app_url
     "MOODLECLIENTOPTIONS__BASEURL"            = "${module.web_app_moodle["primary"].front_door_app_url}/webservice/rest/server.php"
     "MOODLECLIENTOPTIONS__APITOKEN"           = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.web_service_token.name})"
-    "NOTIFICATIONCLIENTOPTIONS__BASEURL"      = module.notification-service.function_app_url
+    "NOTIFICATIONCLIENTOPTIONS__BASEURL"      = module.notification-service.function_app_private_url
     "BASIC_AUTH_USER"                         = var.basic_auth_user
     "BASIC_AUTH_PASSWORD"                     = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/Sites-BasicAuthPassword)"
     "APPLICATIONINSIGHTS_CONNECTION_STRING"   = module.stack.appinsights_connection_string

--- a/terraform/user-management.tf
+++ b/terraform/user-management.tf
@@ -37,6 +37,7 @@ module "user_management" {
     "MOODLECLIENTOPTIONS__BASEURL"            = "${module.web_app_moodle["primary"].front_door_app_url}/webservice/rest/server.php"
     "MOODLECLIENTOPTIONS__APITOKEN"           = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.web_service_token.name})"
     "NOTIFICATIONCLIENTOPTIONS__BASEURL"      = module.notification-service.function_app_private_url
+    "NOTIFICATIONCLIENTOPTIONS__FUNCTIONKEY"  = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.function_key.name})"
     "BASIC_AUTH_USER"                         = var.basic_auth_user
     "BASIC_AUTH_PASSWORD"                     = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/Sites-BasicAuthPassword)"
     "APPLICATIONINSIGHTS_CONNECTION_STRING"   = module.stack.appinsights_connection_string

--- a/terraform/user-management.tf
+++ b/terraform/user-management.tf
@@ -36,7 +36,7 @@ module "user_management" {
     "AUTHCLIENTOPTIONS__BASEURL"              = module.auth_service.front_door_app_url
     "MOODLECLIENTOPTIONS__BASEURL"            = "${module.web_app_moodle["primary"].front_door_app_url}/webservice/rest/server.php"
     "MOODLECLIENTOPTIONS__APITOKEN"           = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.web_service_token.name})"
-    "NOTIFICATIONCLIENTOPTIONS__BASEURL"      = "https://temp.placeholder.url.com" # TODO: Notifications service deployment
+    "NOTIFICATIONCLIENTOPTIONS__BASEURL"      = module.notification-service.function_app_url
     "BASIC_AUTH_USER"                         = var.basic_auth_user
     "BASIC_AUTH_PASSWORD"                     = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/Sites-BasicAuthPassword)"
     "APPLICATIONINSIGHTS_CONNECTION_STRING"   = module.stack.appinsights_connection_string

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -78,6 +78,12 @@ variable "acr_name" {
   type        = string
 }
 
+variable "govnotify_api_key" {
+  description = "GOV.UK Notify API key for sending notifications"
+  type        = string
+  sensitive   = true
+}
+
 variable "acr_resource_group" {
   description = "Azure Container Registry resource group"
   type        = string
@@ -186,6 +192,12 @@ variable "moodle_app_settings" {
 
 variable "user_management_app_settings" {
   description = "Environment specific user management app settings"
+  type        = map(string)
+  default     = {}
+}
+
+variable "notification_service_app_settings" {
+  description = "Environment specific notification service app settings"
   type        = map(string)
   default     = {}
 }


### PR DESCRIPTION
- Adds networking configuration to enable secure communication between user management and the notification service.
- Correctly passes the function app URL to user management
- Passes the function key to user management (future PR to utilise this key in requests)
- Passes the GovNotify API key from the github secrets vault through to Azure KeyVault to be utilised by the notification service.