### PR TITLE
SWIP-819 Allow extended characters in Moodle usernames

### DIFF
--- a/apps/moodle-ddev/.ddev/commands/web/install-oidc-plugin
+++ b/apps/moodle-ddev/.ddev/commands/web/install-oidc-plugin
@@ -99,6 +99,10 @@ if [[ "$INSTALL_ACTIONS" == *"config"* ]]; then
     echo "Curl allowed ports:"
     moosh $MOOSH_COMMAND_LINE_ARGS config-set curlsecurityallowedport ""
 
+    echo "Configuring additional authentication settings ..."
+    echo "Allow extended characters in usernames:"
+    moosh $MOOSH_COMMAND_LINE_ARGS config-set extendedusernamechars 1
+
     echo "Clearing cache to apply all settings changes..."
     moosh $MOOSH_COMMAND_LINE_ARGS cache-clear
 fi


### PR DESCRIPTION
Change to ddev command which is used to configure authentication plugin to also include the additional setting for allowing special characters in usernames. This means that we can leverage this setting to support emails like test+1@test.com (emails are used as usernames when adding users to Moodle via web service calls from the user management app).
Change as part of [SWIP-819](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-819).

[SWIP-819]: https://dfedigital.atlassian.net/browse/SWIP-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ