### PR TITLE
SWIP-826 manage session expiry

### DIFF
--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Infrastructure/Configuration/ServicesExtensions.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Infrastructure/Configuration/ServicesExtensions.cs
@@ -297,7 +297,7 @@ public static class ServicesExtensions
 
                 options.AllowAuthorizationCodeFlow();
 
-                options.SetAccessTokenLifetime(TimeSpan.FromHours(1));
+                options.SetAccessTokenLifetime(TimeSpan.FromHours(4));
 
                 options
                     .UseAspNetCore()

--- a/apps/user-management/apps/frontend.Test/UnitTests/HttpClient/AuthServiceClientTests/AccountsOperationsTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/HttpClient/AuthServiceClientTests/AccountsOperationsTests.cs
@@ -81,7 +81,7 @@ public class AccountsOperationsTests
     }
 
     [Fact]
-    public async Task GetAll_WhenErrorResponseReturned_ReturnsNull()
+    public async Task GetAll_WhenErrorResponseReturned_ThrowsHttpRequestException()
     {
         // Arrange
         var route = $"/api/Accounts";
@@ -98,12 +98,12 @@ public class AccountsOperationsTests
         var paginationRequest = new PaginationRequest(0, 10);
 
         // Act
-        var actualException = await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await sut.Accounts.GetAllAsync(paginationRequest)
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => sut.Accounts.GetAllAsync(paginationRequest)
         );
 
         // Assert
-        actualException.Should().BeOfType<InvalidOperationException>();
+        exception.Message.Should().Be("Failed to get accounts.");
 
         mockHttp.GetMatchCount(request).Should().Be(1);
         mockHttp.VerifyNoOutstandingRequest();
@@ -149,7 +149,7 @@ public class AccountsOperationsTests
     }
 
     [Fact]
-    public async Task GetById_WhenErrorResponseReturned_ReturnsNull()
+    public async Task GetById_WhenErrorResponseReturned_ThrowsHttpRequestException()
     {
         // Arrange
         var personId = Guid.NewGuid();
@@ -165,10 +165,12 @@ public class AccountsOperationsTests
         var sut = BuildSut(mockHttp);
 
         // Act
-        var response = await sut.Accounts.GetByIdAsync(personId);
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => sut.Accounts.GetByIdAsync(personId)
+        );
 
         // Assert
-        response.Should().BeNull();
+        exception.Message.Should().Be($"Failed to get account with ID {personId}.");
 
         mockHttp.GetMatchCount(request).Should().Be(1);
         mockHttp.VerifyNoOutstandingRequest();
@@ -224,7 +226,7 @@ public class AccountsOperationsTests
     }
 
     [Fact]
-    public async Task Create_WhenErrorResponseReturned_ReturnsNull()
+    public async Task Create_WhenErrorResponseReturned_ThrowsHttpRequestException()
     {
         // Arrange
         var createRequest = new CreatePersonRequest
@@ -245,11 +247,13 @@ public class AccountsOperationsTests
         var sut = BuildSut(mockHttp);
 
         // Act
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await sut.Accounts.CreateAsync(createRequest)
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => sut.Accounts.CreateAsync(createRequest)
         );
 
         // Assert
+        exception.Message.Should().Be("Failed to create account.");
+
         mockHttp.GetMatchCount(request).Should().Be(1);
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();
@@ -305,7 +309,7 @@ public class AccountsOperationsTests
     }
 
     [Fact]
-    public async Task Update_WhenErrorResponseReturned_ReturnsNull()
+    public async Task Update_WhenErrorResponseReturned_ThrowsHttpRequestException()
     {
         // Arrange
         var updateRequest = new UpdatePersonRequest
@@ -327,11 +331,13 @@ public class AccountsOperationsTests
         var sut = BuildSut(mockHttp);
 
         // Act
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await sut.Accounts.UpdateAsync(updateRequest)
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => sut.Accounts.UpdateAsync(updateRequest)
         );
 
         // Assert
+        exception.Message.Should().Be("Failed to update account.");
+
         mockHttp.GetMatchCount(request).Should().Be(1);
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();

--- a/apps/user-management/apps/frontend.Test/UnitTests/HttpClient/AuthServiceClientTests/OrganisationsOperationsTests.cs
+++ b/apps/user-management/apps/frontend.Test/UnitTests/HttpClient/AuthServiceClientTests/OrganisationsOperationsTests.cs
@@ -78,7 +78,7 @@ public class OrganisationsOperationsTests
     }
 
     [Fact]
-    public async Task GetAll_WhenErrorResponseReturned_ReturnsNull()
+    public async Task GetAll_WhenErrorResponseReturned_ThrowsHttpRequestException()
     {
         // Arrange
         var route = "/api/Organisations";
@@ -95,12 +95,12 @@ public class OrganisationsOperationsTests
         var paginationRequest = new PaginationRequest(0, 10);
 
         // Act
-        var actualException = await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await sut.Organisations.GetAllAsync(paginationRequest)
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => sut.Organisations.GetAllAsync(paginationRequest)
         );
 
         // Assert
-        actualException.Should().BeOfType<InvalidOperationException>();
+        exception.Message.Should().Be("Failed to get organisations.");
 
         mockHttp.GetMatchCount(request).Should().Be(1);
         mockHttp.VerifyNoOutstandingRequest();
@@ -147,7 +147,7 @@ public class OrganisationsOperationsTests
     }
 
     [Fact]
-    public async Task GetById_WhenErrorResponseReturned_ReturnsNull()
+    public async Task GetById_WhenErrorResponseReturned_ThrowsHttpRequestException()
     {
         // Arrange
         var organisationId = Guid.NewGuid();
@@ -163,10 +163,12 @@ public class OrganisationsOperationsTests
         var sut = BuildSut(mockHttp);
 
         // Act
-        var response = await sut.Organisations.GetByIdAsync(organisationId);
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => sut.Organisations.GetByIdAsync(organisationId)
+        );
 
         // Assert
-        response.Should().BeNull();
+        exception.Message.Should().Be($"Failed to get organisation with ID {organisationId}.");
 
         mockHttp.GetMatchCount(request).Should().Be(1);
         mockHttp.VerifyNoOutstandingRequest();

--- a/apps/user-management/apps/frontend/Filters/UnauthorizedExceptionFilter.cs
+++ b/apps/user-management/apps/frontend/Filters/UnauthorizedExceptionFilter.cs
@@ -1,0 +1,17 @@
+using System.Net;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace Dfe.Sww.Ecf.Frontend.Filters;
+
+public class UnauthorizedExceptionFilter : IExceptionFilter
+{
+    public void OnException(ExceptionContext context)
+    {
+        if (context.Exception is HttpRequestException httpException && httpException.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            context.ExceptionHandled = true;
+            context.Result = new ChallengeResult();
+        }
+    }
+}

--- a/apps/user-management/apps/frontend/HttpClients/AuthService/Operations/AccountsOperations.cs
+++ b/apps/user-management/apps/frontend/HttpClients/AuthService/Operations/AccountsOperations.cs
@@ -1,6 +1,4 @@
-﻿using System.Security.Claims;
-using System.Text.Json;
-using Dfe.Sww.Ecf.Frontend.Helpers;
+﻿using System.Text.Json;
 using Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Interfaces;
 using Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Models;
 using Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Models.Pagination;
@@ -8,11 +6,8 @@ using Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Models.Pagination;
 namespace Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Operations;
 
 public class AccountsOperations(AuthServiceClient authServiceClient)
-    : IAccountsOperations
+    : BaseOperations, IAccountsOperations
 {
-    private static JsonSerializerOptions? SerializerOptions { get; } =
-        new(JsonSerializerDefaults.Web) { Converters = { new BooleanConverter() } };
-
     public async Task<PaginationResult<Person>> GetAllAsync(PaginationRequest request, Guid? organisationId = null)
     {
         var organisationIdString = organisationId.HasValue
@@ -22,10 +17,7 @@ public class AccountsOperations(AuthServiceClient authServiceClient)
         var route = $"/api/Accounts?Offset={request.Offset}&PageSize={request.PageSize}&organisationId={organisationIdString}";
         var httpResponse = await authServiceClient.HttpClient.GetAsync(route);
 
-        if (!httpResponse.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException("Failed to get accounts.");
-        }
+        HandleHttpResponse(httpResponse, "Failed to get accounts.");
 
         var response = await httpResponse.Content.ReadAsStringAsync();
 
@@ -46,10 +38,7 @@ public class AccountsOperations(AuthServiceClient authServiceClient)
     {
         var httpResponse = await authServiceClient.HttpClient.GetAsync($"/api/Accounts/{id}");
 
-        if (!httpResponse.IsSuccessStatusCode)
-        {
-            return null;
-        }
+        HandleHttpResponse(httpResponse, $"Failed to get account with ID {id}.");
 
         var response = await httpResponse.Content.ReadAsStringAsync();
 
@@ -64,10 +53,8 @@ public class AccountsOperations(AuthServiceClient authServiceClient)
             "/api/Accounts/Create",
             createPersonRequest
         );
-        if (!httpResponse.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException("Failed to create account.");
-        }
+
+        HandleHttpResponse(httpResponse, "Failed to create account.");
 
         var response = await httpResponse.Content.ReadAsStringAsync();
         var createdPerson = JsonSerializer.Deserialize<Person>(response, SerializerOptions);
@@ -85,10 +72,7 @@ public class AccountsOperations(AuthServiceClient authServiceClient)
             $"/api/Accounts/{accountId}/linking-token"
         );
 
-        if (!httpResponse.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException("Failed to get account linking token.");
-        }
+        HandleHttpResponse(httpResponse, "Failed to get account linking token.");
 
         var response = await httpResponse.Content.ReadAsStringAsync();
 
@@ -111,10 +95,8 @@ public class AccountsOperations(AuthServiceClient authServiceClient)
             "/api/Accounts",
             updatePersonRequest
         );
-        if (!httpResponse.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException("Failed to update account.");
-        }
+
+        HandleHttpResponse(httpResponse, "Failed to update account.");
 
         var response = await httpResponse.Content.ReadAsStringAsync();
         var updatedPerson = JsonSerializer.Deserialize<Person>(response, SerializerOptions);

--- a/apps/user-management/apps/frontend/HttpClients/AuthService/Operations/BaseOperations.cs
+++ b/apps/user-management/apps/frontend/HttpClients/AuthService/Operations/BaseOperations.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using Dfe.Sww.Ecf.Frontend.Helpers;
+
+namespace Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Operations;
+
+public class BaseOperations
+{
+    protected static JsonSerializerOptions? SerializerOptions { get; } =
+        new(JsonSerializerDefaults.Web) { Converters = { new BooleanConverter() } };
+
+    protected static void HandleHttpResponse(HttpResponseMessage httpResponse, string? failureMessage = null)
+    {
+        if (!httpResponse.IsSuccessStatusCode)
+        {
+            var message = failureMessage ?? $"API request failed with status code {httpResponse.StatusCode}";
+            throw new HttpRequestException(message, null, httpResponse.StatusCode);
+        }
+    }
+
+}

--- a/apps/user-management/apps/frontend/HttpClients/AuthService/Operations/OrganisationOperations.cs
+++ b/apps/user-management/apps/frontend/HttpClients/AuthService/Operations/OrganisationOperations.cs
@@ -1,5 +1,4 @@
 ﻿using System.Text.Json;
-using Dfe.Sww.Ecf.Frontend.Helpers;
 using Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Interfaces;
 using Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Models;
 using Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Models.Pagination;
@@ -7,20 +6,14 @@ using Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Models.Pagination;
 namespace Dfe.Sww.Ecf.Frontend.HttpClients.AuthService.Operations;
 
 public class OrganisationOperations(AuthServiceClient authServiceClient)
-    : IOrganisationOperations
+    : BaseOperations, IOrganisationOperations
 {
-    private static JsonSerializerOptions? SerializerOptions { get; } =
-        new(JsonSerializerDefaults.Web) { Converters = { new BooleanConverter() } };
-
     public async Task<PaginationResult<OrganisationDto>> GetAllAsync(PaginationRequest request)
     {
         var route = $"/api/Organisations?Offset={request.Offset}&PageSize={request.PageSize}";
         var httpResponse = await authServiceClient.HttpClient.GetAsync(route);
 
-        if (!httpResponse.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException("Failed to get organisations.");
-        }
+        HandleHttpResponse(httpResponse, "Failed to get organisations.");
 
         var response = await httpResponse.Content.ReadAsStringAsync();
 
@@ -44,10 +37,7 @@ public class OrganisationOperations(AuthServiceClient authServiceClient)
             createOrganisationRequest
         );
 
-        if (!httpResponse.IsSuccessStatusCode)
-        {
-            throw new InvalidOperationException("Failed to create organisation.");
-        }
+        HandleHttpResponse(httpResponse, "Failed to create organisation.");
 
         var response = await httpResponse.Content.ReadAsStringAsync();
         var createdOrganisation = JsonSerializer.Deserialize<OrganisationDto>(response, SerializerOptions);
@@ -62,10 +52,7 @@ public class OrganisationOperations(AuthServiceClient authServiceClient)
     {
         var httpResponse = await authServiceClient.HttpClient.GetAsync($"/api/Organisations/{id}");
 
-        if (!httpResponse.IsSuccessStatusCode)
-        {
-            return null;
-        }
+        HandleHttpResponse(httpResponse, $"Failed to get organisation with ID {id}.");
 
         var response = await httpResponse.Content.ReadAsStringAsync();
         var organisation = JsonSerializer.Deserialize<OrganisationDto>(response, SerializerOptions);

--- a/apps/user-management/apps/frontend/Program.cs
+++ b/apps/user-management/apps/frontend/Program.cs
@@ -1,6 +1,7 @@
 ﻿using Dfe.Sww.Ecf.Frontend.Authorisation;
 using Dfe.Sww.Ecf.Frontend.Configuration;
 using Dfe.Sww.Ecf.Frontend.Configuration.Notification;
+using Dfe.Sww.Ecf.Frontend.Filters;
 using Dfe.Sww.Ecf.Frontend.Helpers;
 using Dfe.Sww.Ecf.Frontend.Installers;
 using Dfe.Sww.Ecf.Frontend.Routing;
@@ -54,6 +55,11 @@ builder
         );
         options.Conventions.AuthorizeFolder("/ManageAccounts");
     });
+
+builder.Services.AddControllersWithViews(options =>
+{
+    options.Filters.Add<UnauthorizedExceptionFilter>();
+});
 
 builder.Services.AddAuthorizationBuilder()
     .AddPolicy("ManageAccountsPolicy", policy =>

--- a/apps/user-management/apps/frontend/appsettings.Development.json
+++ b/apps/user-management/apps/frontend/appsettings.Development.json
@@ -16,7 +16,8 @@
         "AuthorityUrl": "https://localhost:7236",
         "ClientId": "dfe-sww-ecf-frontend-dev",
         "ClientSecret": "Devel0pm3ntSecr4t",
-        "EnableDevelopmentBackdoor": false
+        "EnableDevelopmentBackdoor": false,
+        "SessionLifetimeMinutes": 60
     },
     "SocialWorkEnglandClientOptions": {
         "BaseUrl": "https://localhost:44359",


### PR DESCRIPTION
Change to fix errors captured in [SWIP-826](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-826) by better management of session expiry:

- auth service changes for access token to expire after 4 hours (absolute timeout)
- frontend changes to api calls for account operations and organisation operations to handle 401 response from the auth service (which would happen after the 4 hours pass) and throw a http response error
- exception filter to trigger the authentication challenge which results in a redirect to the signin page
- absolute session timeout handling for the frontend for standard page requests (not api calls)
- frontend idle session timeout set to 60 minutes so the user has to reauthenticate after 60 minutes of inactivity
- unit test updates

[SWIP-826]: https://dfedigital.atlassian.net/browse/SWIP-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ