### PR TITLE
SWIP-941 - Seed initial user as admin

### DIFF
--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Infrastructure/Security/ClaimsBuilder.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Infrastructure/Security/ClaimsBuilder.cs
@@ -8,11 +8,12 @@ public class ClaimsBuilder(ClaimsIdentity identity, OpenIddictRequest request)
 {
     private readonly ClaimsIdentity _identity =
         identity ?? throw new ArgumentNullException(nameof(identity));
+
     private readonly OpenIddictRequest _request =
         request ?? throw new ArgumentNullException(nameof(request));
 
     /// <summary>
-    /// Add a claim if the specified scope is present.
+    ///     Add a claim if the specified scope is present.
     /// </summary>
     public ClaimsBuilder AddIfScope(string scope, string claimType, Func<string?> valueProvider)
     {
@@ -26,11 +27,12 @@ public class ClaimsBuilder(ClaimsIdentity identity, OpenIddictRequest request)
         {
             _identity.SetClaim(claimType, value);
         }
+
         return this;
     }
 
     /// <summary>
-    /// Add multiple role claims if the "roles" scope is present.
+    ///     Add multiple role claims if the "roles" scope is present.
     /// </summary>
     public async Task<ClaimsBuilder> AddRoleClaimsIfScopeAsync(
         string scope,
@@ -56,7 +58,7 @@ public class ClaimsBuilder(ClaimsIdentity identity, OpenIddictRequest request)
     }
 
     /// <summary>
-    /// Add the organisation id claim if the "organisation" scope is present.
+    ///     Add the organisation id claim if the "organisation" scope is present.
     /// </summary>
     public async Task<ClaimsBuilder> AddOrganisationIdClaimIfScopeAsync(
         string scope,
@@ -71,10 +73,10 @@ public class ClaimsBuilder(ClaimsIdentity identity, OpenIddictRequest request)
 
         var organisationIdClaim = await dbContext
             .PersonOrganisations.Where(po => po.PersonId == personId)
-            .Where(po => po.EndDate == null || (po.StartDate >= po.EndDate))
+            .Where(po => po.EndDate == null || po.StartDate >= po.EndDate)
             .Select(po => po.OrganisationId.ToString()
             )
-            .FirstAsync();
+            .FirstOrDefaultAsync();
 
         if (!string.IsNullOrEmpty(organisationIdClaim))
         {

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/appsettings.Development.json
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/appsettings.Development.json
@@ -80,10 +80,8 @@
     "ScriptHash": "sha256-j7OoGArf6XW6YY4cAyS3riSSvrJRqpSi1fOF9vQ5SrI="
   },
   "DatabaseSeed": {
-    "OrganisationId": "00000000-0000-0000-0000-000000000001",
-    "OrganisationName": "Test Organisation",
     "PersonId": "00000000-0000-0000-0001-000000000001",
-    "RoleId": 800,
+    "RoleId": 1000,
     "OneLoginEmail": "swip.test@education.gov.uk"
   },
   // Local simulator

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DatabaseSeeder.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DatabaseSeeder.cs
@@ -4,14 +4,14 @@ namespace Dfe.Sww.Ecf.Core.DataStore.Postgres;
 
 public static class DatabaseSeeder
 {
-    public static async Task SeedOrganisationAsync(DbContext db, Guid orgId, CancellationToken ct)
+    public static async Task SeedOrganisationAsync(DbContext db, Guid orgId, string? orgName, CancellationToken ct)
     {
         await db.Set<Organisation>().AddIfNotExistsAsync(
             o => o.OrganisationId == orgId,
             () => new Organisation
             {
                 OrganisationId = orgId,
-                OrganisationName = "Test Organisation",
+                OrganisationName = orgName ?? "Test Organisation",
                 ExternalOrganisationId = 0
             },
             ct

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DatabaseSeeder.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DatabaseSeeder.cs
@@ -18,7 +18,7 @@ public static class DatabaseSeeder
         );
     }
 
-    public static async Task SeedPersonAsync(DbContext db, Guid personId, CancellationToken ct)
+    public static async Task SeedPersonAsync(DbContext db, Guid personId, string email, CancellationToken ct)
     {
         await db.Set<Person>().AddIfNotExistsAsync(
             p => p.PersonId == personId,
@@ -26,8 +26,8 @@ public static class DatabaseSeeder
             {
                 PersonId = personId,
                 FirstName = "Test",
-                LastName = "Coordinator",
-                EmailAddress = "test.coordinator@test-org.com",
+                LastName = "User",
+                EmailAddress = email,
                 CreatedOn = DateTime.UtcNow,
                 Status = PersonStatus.Active
             },

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DbContextOptionsBuilderExtensions.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DbContextOptionsBuilderExtensions.cs
@@ -10,7 +10,7 @@ public static class DbContextOptionsBuilderExtensions
     {
         builder.UseAsyncSeeding(async (db, _, ct) =>
         {
-            await DatabaseSeeder.SeedPersonAsync(db, seedOptions.PersonId, ct);
+            await DatabaseSeeder.SeedPersonAsync(db, seedOptions.PersonId, seedOptions.OneLoginEmail, ct);
             await DatabaseSeeder.SeedPersonRoleAsync(db, seedOptions.PersonId, seedOptions.RoleId, ct);
 
             if (seedOptions.OrganisationId != null)

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DbContextOptionsBuilderExtensions.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/DbContextOptionsBuilderExtensions.cs
@@ -10,10 +10,15 @@ public static class DbContextOptionsBuilderExtensions
     {
         builder.UseAsyncSeeding(async (db, _, ct) =>
         {
-            await DatabaseSeeder.SeedOrganisationAsync(db, seedOptions.OrganisationId, ct);
             await DatabaseSeeder.SeedPersonAsync(db, seedOptions.PersonId, ct);
-            await DatabaseSeeder.SeedPersonOrganisationAsync(db, seedOptions.OrganisationId, seedOptions.PersonId, ct);
             await DatabaseSeeder.SeedPersonRoleAsync(db, seedOptions.PersonId, seedOptions.RoleId, ct);
+
+            if (seedOptions.OrganisationId != null)
+            {
+                var orgId = (Guid)seedOptions.OrganisationId;
+                await DatabaseSeeder.SeedOrganisationAsync(db, orgId, seedOptions.OrganisationName, ct);
+                await DatabaseSeeder.SeedPersonOrganisationAsync(db, orgId, seedOptions.PersonId, ct);
+            }
 
             await db.SaveChangesAsync(ct);
         });

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/Infrastructure/Configuration/DatabaseSeedOptions.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/Infrastructure/Configuration/DatabaseSeedOptions.cs
@@ -2,8 +2,8 @@ namespace Dfe.Sww.Ecf.Core.Infrastructure.Configuration;
 
 public class DatabaseSeedOptions
 {
-    public Guid OrganisationId { get; init; }
-    public string OrganisationName { get; init; } = string.Empty;
+    public Guid? OrganisationId { get; init; }
+    public string? OrganisationName { get; init; } = string.Empty;
     public Guid PersonId { get; init; }
     public int RoleId { get; init; }
     public string OneLoginEmail { get; init; } = string.Empty;

--- a/apps/auth-service/tools/onelogin-simulator/compose.yml
+++ b/apps/auth-service/tools/onelogin-simulator/compose.yml
@@ -7,6 +7,7 @@ services:
       - SIMULATOR_URL=https://localhost:9010/onelogin
       - REDIRECT_URLS=https://localhost:7236/_onelogin/callback
       - INTERACTIVE_MODE=true
+      - EMAIL=swip.test@education.gov.uk
   caddy:
     image: caddy:latest
     restart: unless-stopped

--- a/terraform/envs/d01/env.tfvars
+++ b/terraform/envs/d01/env.tfvars
@@ -30,10 +30,8 @@ moodle_instances = {
 auth_service_app_settings = {
   "FEATUREFLAGS__ENABLEDEVELOPEREXCEPTIONPAGE" = "true"
   "FEATUREFLAGS__ENABLESWAGGER"                = "true"
-  "DATABASESEED__ORGANISATIONID"               = "00000000-0000-0000-0000-000000000001"
-  "DATABASESEED__ORGANISATIONNAME"             = "Test Organisation"
   "DATABASESEED__PERSONID"                     = "00000000-0000-0000-0001-000000000001"
-  "DATABASESEED__ROLEID"                       = 800
+  "DATABASESEED__ROLEID"                       = 1000
   "DATABASESEED__ONELOGINEMAIL"                = "swip.test@education.gov.uk"
 }
 one_login_client_id = "EsYDRVMBVfTviM3KcsszKUrL_Fw"

--- a/terraform/envs/d02/env.tfvars
+++ b/terraform/envs/d02/env.tfvars
@@ -32,10 +32,8 @@ moodle_instances = {
 auth_service_app_settings = {
   "FEATUREFLAGS__ENABLEDEVELOPEREXCEPTIONPAGE" = "true"
   "FEATUREFLAGS__ENABLESWAGGER"                = "true"
-  "DATABASESEED__ORGANISATIONID"               = "00000000-0000-0000-0000-000000000001"
-  "DATABASESEED__ORGANISATIONNAME"             = "Test Organisation"
   "DATABASESEED__PERSONID"                     = "00000000-0000-0000-0001-000000000001"
-  "DATABASESEED__ROLEID"                       = 800
+  "DATABASESEED__ROLEID"                       = 1000
   "DATABASESEED__ONELOGINEMAIL"                = "swip.test@education.gov.uk"
 }
 one_login_client_id = "C-MUL4V97M8VYdSsi6qQFy0PRI8"

--- a/terraform/envs/d03/env.tfvars
+++ b/terraform/envs/d03/env.tfvars
@@ -32,10 +32,8 @@ moodle_instances = {
 auth_service_app_settings = {
   "FEATUREFLAGS__ENABLEDEVELOPEREXCEPTIONPAGE" = "true"
   "FEATUREFLAGS__ENABLESWAGGER"                = "true"
-  "DATABASESEED__ORGANISATIONID"               = "00000000-0000-0000-0000-000000000001"
-  "DATABASESEED__ORGANISATIONNAME"             = "Test Organisation"
   "DATABASESEED__PERSONID"                     = "00000000-0000-0000-0001-000000000001"
-  "DATABASESEED__ROLEID"                       = 800
+  "DATABASESEED__ROLEID"                       = 1000
   "DATABASESEED__ONELOGINEMAIL"                = "swip.test@education.gov.uk"
 }
 one_login_client_id = "kxYIW8mpUue-vHUFygaIBBHsNYY"


### PR DESCRIPTION
- Seeds the initial user with the admin role
- Removes config to seed initial org as it's no longer needed, but kept the code as optional for potential future use in automated tests
- Fixes an issues where setting the orgId claim was throwing an exception when the user wasn't part of an org (like an admin user)