### PR TITLE
SWIP-996 Run workflows on PRs to development instead

### DIFF
--- a/.github/workflows/build-and-optionally-deploy-auth-service.yml
+++ b/.github/workflows/build-and-optionally-deploy-auth-service.yml
@@ -16,7 +16,7 @@ on:
           - d03
   pull_request:
     branches:
-      - main
+      - development
     paths:
       - "apps/auth-service/**"
 

--- a/.github/workflows/build-and-optionally-deploy-db-ops-service.yml
+++ b/.github/workflows/build-and-optionally-deploy-db-ops-service.yml
@@ -15,7 +15,7 @@ on:
           - d03
   pull_request:
     branches:
-      - main
+      - development
     paths:
       - "apps/db-operations-service/**"
 

--- a/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
+++ b/.github/workflows/build-and-optionally-deploy-moodle-apps.yml
@@ -29,7 +29,7 @@ on:
           - d03
   pull_request:
     branches:
-      - main
+      - development
     paths:
       - "apps/moodle-apps-azure/**"
       - "apps/moodle-ddev/**"

--- a/.github/workflows/build-and-optionally-deploy-notification-api.yml
+++ b/.github/workflows/build-and-optionally-deploy-notification-api.yml
@@ -15,7 +15,7 @@ on:
           - d03
   pull_request:
     branches:
-      - main
+      - development
     paths:
       - "apps/user-management/apps/notification-service/**"
       - "apps/user-management/apps/notification-service-test/**"

--- a/.github/workflows/build-and-optionally-deploy-proxy-service.yml
+++ b/.github/workflows/build-and-optionally-deploy-proxy-service.yml
@@ -16,7 +16,7 @@ on:
           - d03
   pull_request:
     branches:
-      - main
+      - development
     paths:
       - "apps/proxy-app-azure/**"
 

--- a/.github/workflows/build-and-optionally-deploy-user-management.yml
+++ b/.github/workflows/build-and-optionally-deploy-user-management.yml
@@ -16,7 +16,7 @@ on:
           - d03
   pull_request:
     branches:
-      - main
+      - development
     paths:
       - "apps/user-management/**"
 

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -1,10 +1,10 @@
 name: Checkov
 on:
-  # Only run the terraform linting on PR to main - otherwise wastes build resources
+  # Only run the terraform linting on PR to development - otherwise wastes build resources
   # as it also runs as part of terraform deploy on any branch
   pull_request:
     branches:
-      - main
+      - development
     paths:
       - 'terraform/**'
 

--- a/.github/workflows/scan-codeql.yml
+++ b/.github/workflows/scan-codeql.yml
@@ -13,7 +13,7 @@ name: "CodeQL Advanced"
 
 on:
   pull_request:
-    branches: [main]
+    branches: [development]
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:

--- a/.github/workflows/scan-trivy.yml
+++ b/.github/workflows/scan-trivy.yml
@@ -2,7 +2,7 @@ name: Trivy Vulnerability Scan
 
 on:
   pull_request:
-    branches: [main]
+    branches: [development]
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Changed to workflows to run on PRs for development instead of main as part of the updated branching stategy. See ticket for more details - [SWIP-996](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-996)