### PR TITLE
SWIP-684 - Allow access to db-jobs-app via front door

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -29,3 +29,4 @@ jobs:
           directory: terraform/
           framework: terraform
           skip_check: CKV2_AZURE_33
+          quiet: true

--- a/.github/workflows/db-backup-restore.yml
+++ b/.github/workflows/db-backup-restore.yml
@@ -52,17 +52,24 @@ jobs:
           tenant-id: ${{ secrets.AZ_TENANT_ID }}
           subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
 
-      - name: Get Function Key from Key Vault
+      - name: Get Function Key and Front Door URL from Key Vault
         run: |
           FUNCTION_KEY=$(az keyvault secret show \
             --name "DbOperationsService-FunctionKey" \
             --vault-name "s205${{ inputs.instance }}-kv-primary" \
             --query value -o tsv)
 
-          # Mask the secret to prevent it from appearing in logs
+          FRONTDOOR_HOSTNAME=$(az keyvault secret show \
+            --name "DbOperationsService-FrontDoorUrl" \
+            --vault-name "s205${{ inputs.instance }}-kv-primary" \
+            --query value -o tsv)
+
+          # Mask the secrets to prevent them from appearing in logs
           echo "::add-mask::$FUNCTION_KEY"
+          echo "::add-mask::$FRONTDOOR_HOSTNAME"
 
           echo "FUNCTION_KEY=$FUNCTION_KEY" >> $GITHUB_ENV
+          echo "FRONTDOOR_HOSTNAME=$FRONTDOOR_HOSTNAME" >> $GITHUB_ENV
 
       - name: Validate inputs
         run: |
@@ -81,7 +88,7 @@ jobs:
       - name: Backup ${{ inputs.db-name }} database on ${{ inputs.instance }}
         run: |
           FUNCTION_APP_NAME="s205${{ inputs.instance }}-fa-db-jobs"
-          ENDPOINT="https://$FUNCTION_APP_NAME.azurewebsites.net/api/DbOperationsFunction"
+          ENDPOINT="https://$FRONTDOOR_HOSTNAME/api/DbOperationsFunction"
           STORAGE_ACCOUNT="s205${{ inputs.instance }}sabackups"
           CONTAINER="s205${{ inputs.instance }}-${{ inputs.container-suffix }}-backups"
 
@@ -135,17 +142,24 @@ jobs:
           tenant-id: ${{ secrets.AZ_TENANT_ID }}
           subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
 
-      - name: Get Function Key from Key Vault
+      - name: Get Function Key and Front Door URL from Key Vault
         run: |
           FUNCTION_KEY=$(az keyvault secret show \
             --name "DbOperationsService-FunctionKey" \
             --vault-name "s205${{ inputs.instance }}-kv-primary" \
             --query value -o tsv)
 
-          # Mask the secret to prevent it from appearing in logs
+          FRONTDOOR_HOSTNAME=$(az keyvault secret show \
+            --name "DbOperationsService-FrontDoorUrl" \
+            --vault-name "s205${{ inputs.instance }}-kv-primary" \
+            --query value -o tsv)
+
+          # Mask the secrets to prevent them from appearing in logs
           echo "::add-mask::$FUNCTION_KEY"
+          echo "::add-mask::$FRONTDOOR_HOSTNAME"
 
           echo "FUNCTION_KEY=$FUNCTION_KEY" >> $GITHUB_ENV
+          echo "FRONTDOOR_HOSTNAME=$FRONTDOOR_HOSTNAME" >> $GITHUB_ENV
 
       - name: Validate inputs
         run: |
@@ -164,7 +178,7 @@ jobs:
       - name: Restore ${{ inputs.db-name }} database on ${{ inputs.instance }}
         run: |
           FUNCTION_APP_NAME="s205${{ inputs.instance }}-fa-db-jobs"
-          ENDPOINT="https://$FUNCTION_APP_NAME.azurewebsites.net/api/DbOperationsFunction"
+          ENDPOINT="https://$FRONTDOOR_HOSTNAME/api/DbOperationsFunction"
           STORAGE_ACCOUNT="s205${{ inputs.instance }}sabackups"
           CONTAINER="s205${{ inputs.instance }}-${{ inputs.container-suffix }}-backups"
 

--- a/terraform/db-jobs-app.tf
+++ b/terraform/db-jobs-app.tf
@@ -108,3 +108,15 @@ resource "azurerm_key_vault_secret" "db_operations_function_key" {
 
   #checkov:skip=CKV_AZURE_41:Function key doesn't need expiry date
 }
+
+# Store the Front Door hostname in Key Vault for workflow retrieval
+resource "azurerm_key_vault_secret" "db_operations_frontdoor_url" {
+  name         = "DbOperationsService-FrontDoorUrl"
+  value        = azurerm_cdn_frontdoor_endpoint.fd_endpoint.host_name
+  key_vault_id = module.stack.kv_id
+  content_type = "front door hostname"
+
+  depends_on = [azurerm_cdn_frontdoor_endpoint.fd_endpoint]
+
+  #checkov:skip=CKV_AZURE_41:URL doesn't need expiry date
+}

--- a/terraform/db-jobs-app.tf
+++ b/terraform/db-jobs-app.tf
@@ -22,6 +22,7 @@ module "db-jobs-app" {
   subnet_functionapp_privateendpoint_id = module.stack.subnet_functionapp_privateendpoint_id
   private_dns_zone_id                   = module.stack.private_dns_zone_id
   public_network_access_enabled         = true
+  frontdoor_traffic_only                = true
   app_settings = merge({
     "CONNECTIONSTRINGS__DEFAULTCONNECTION" = "Host=${module.stack.postgres_db_host};Username=${module.stack.postgres_username};"
     "STORAGECONNECTIONSTRING"              = "@Microsoft.KeyVault(SecretUri=${module.stack.full_backup_storage_connectionstring_uri})"

--- a/terraform/db-jobs-app.tf
+++ b/terraform/db-jobs-app.tf
@@ -21,6 +21,7 @@ module "db-jobs-app" {
   function_worker_runtime               = "dotnet-isolated"
   subnet_functionapp_privateendpoint_id = module.stack.subnet_functionapp_privateendpoint_id
   private_dns_zone_id                   = module.stack.private_dns_zone_id
+  public_network_access_enabled         = true
   app_settings = merge({
     "CONNECTIONSTRINGS__DEFAULTCONNECTION" = "Host=${module.stack.postgres_db_host};Username=${module.stack.postgres_username};"
     "STORAGECONNECTIONSTRING"              = "@Microsoft.KeyVault(SecretUri=${module.stack.full_backup_storage_connectionstring_uri})"

--- a/terraform/modules/function-app/function-app.tf
+++ b/terraform/modules/function-app/function-app.tf
@@ -6,7 +6,7 @@ resource "azurerm_linux_function_app" "function_app" {
   storage_account_name          = var.storage_account_name
   storage_account_access_key    = var.storage_account_access_key
   https_only                    = true
-  public_network_access_enabled = false
+  public_network_access_enabled = var.public_network_access_enabled
 
   identity {
     type = "SystemAssigned"

--- a/terraform/modules/function-app/function-app.tf
+++ b/terraform/modules/function-app/function-app.tf
@@ -6,6 +6,7 @@ resource "azurerm_linux_function_app" "function_app" {
   storage_account_name          = var.storage_account_name
   storage_account_access_key    = var.storage_account_access_key
   https_only                    = true
+  #checkov:skip=CKV_AZURE_221:IP Restrictions in place to only allow front door
   public_network_access_enabled = var.public_network_access_enabled
 
   identity {

--- a/terraform/modules/function-app/function-app.tf
+++ b/terraform/modules/function-app/function-app.tf
@@ -19,6 +19,19 @@ resource "azurerm_linux_function_app" "function_app" {
     health_check_eviction_time_in_min       = var.health_check_path == "" ? 2 : var.health_check_eviction_time_in_min
     vnet_route_all_enabled                  = true
     container_registry_use_managed_identity = true
+
+    ip_restriction_default_action = var.frontdoor_traffic_only ? "Deny" : "Allow"
+
+    dynamic "ip_restriction" {
+      for_each = var.frontdoor_traffic_only ? [1] : []
+      content {
+        name        = "Allow Azure Front Door"
+        action      = "Allow"
+        priority    = 100
+        service_tag = "AzureFrontDoor.Frontend"
+      }
+    }
+
     application_stack {
       docker {
         image_name   = var.docker_image_name

--- a/terraform/modules/function-app/function-app.tf
+++ b/terraform/modules/function-app/function-app.tf
@@ -29,7 +29,7 @@ resource "azurerm_linux_function_app" "function_app" {
         name        = "Allow Azure Front Door"
         action      = "Allow"
         priority    = 100
-        service_tag = "AzureFrontDoor.Frontend"
+        service_tag = "AzureFrontDoor.Backend"
       }
     }
 

--- a/terraform/modules/function-app/function-app.tf
+++ b/terraform/modules/function-app/function-app.tf
@@ -7,7 +7,7 @@ resource "azurerm_linux_function_app" "function_app" {
   storage_account_access_key    = var.storage_account_access_key
   https_only                    = true
   #checkov:skip=CKV_AZURE_221:IP Restrictions in place to only allow front door
-  public_network_access_enabled = var.public_network_access_enabled
+  public_network_access_enabled = var.public_network_access_enabled && var.frontdoor_traffic_only
 
   identity {
     type = "SystemAssigned"

--- a/terraform/modules/function-app/variables.tf
+++ b/terraform/modules/function-app/variables.tf
@@ -121,3 +121,9 @@ variable "public_network_access_enabled" {
   type        = bool
   default     = false
 }
+
+variable "frontdoor_traffic_only" {
+  description = "Whether to restrict access to only allow traffic from Azure Front Door"
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/function-app/variables.tf
+++ b/terraform/modules/function-app/variables.tf
@@ -115,3 +115,9 @@ variable "private_dns_zone_id" {
   description = "The ID of the private DNS zone"
   type        = string
 }
+
+variable "public_network_access_enabled" {
+  description = "Whether or not to allow public access to the function app"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
- Adds the ability to create a function app with public access enabled and also the option to ensure that access is restricted to requests that come via front door
	- For security, public access can only be enabled if front door restrictions are in place
- Enabled this for the new db-jobs-app