### PR TITLE
SWIP-1054 replace moodle sticky footer with buttons

### DIFF
--- a/apps/moodle-ddev/.ddev/commands/web/install-theme
+++ b/apps/moodle-ddev/.ddev/commands/web/install-theme
@@ -40,14 +40,6 @@ mv /tmp/theme/govuk/ /var/www/html/public/theme/govuk
 rm -rf /tmp/govuk-moodle-theme.zip /tmp/theme
 echo "Govuk theme updated to release ${RELEASE}."
 
-echo "Updating config.php to set theme to govuk..."
-CONFIG_FILE="/var/www/html/public/config.php"
-if grep -q "\$CFG->theme" "$CONFIG_FILE"; then
-  sed -i "s/\(\$CFG->theme\s*=\s*\).*/\1'govuk';/" "$CONFIG_FILE"
-else
-  echo "\$CFG->theme = 'govuk';" >> "$CONFIG_FILE"
-fi
-
 # For Azure, we want the ability to copy the theme but delay the upgrade til deployment
 if [[ "$2" != "--copy-only" ]]; then
   echo "Running Moodle upgrade..."

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/config.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/config.php
@@ -3,6 +3,12 @@ defined('MOODLE_INTERNAL') || die();
 
 $THEME->name = 'govuk_swpdp';
 
-$THEME->parents = ['boost', 'govuk'];
+/**
+ * To inherit both govuk and boost styles, both themes need listing as parents.
+ * The order of the parents matters. For this theme to inherit
+ * govuk templates that overwrite boost templates,
+ * govuk must be listed first
+ */
+$THEME->parents = ['govuk','boost'];
 
 $THEME->rendererfactory = 'theme_overridden_renderer_factory';

--- a/apps/moodle-docker/config.php
+++ b/apps/moodle-docker/config.php
@@ -47,9 +47,6 @@ $CFG->admin = getenv('MOODLE_ADMIN_USER');
 
 $CFG->directorypermissions = 02777;
 
-if (getenv('MOODLE_SWITCH_OFF_GOVUK_THEMING') !== 'true') {
-  $CFG->theme = 'govuk'; 
-}
 if (getenv('MOODLE_SWITCH_OFF_OAUTH') === 'true') {
   $CFG->auth = 'manual'; 
 }


### PR DESCRIPTION
Changes as part of [SWIP-1054](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-1054):
- change order of govuk_swpdp theme parents so that templates overwritten by govuk take precendence over the templates in the boost theme
- remove a theme being specifid in Moodle config.php (we may want to reintroduce this at some point, as in production this should be hardcoded; teraform variable to support this has not been removed from the codebase - 'MOODLE_SWITCH_OFF_GOVUK_THEMING')