### PR TITLE
SWIP-906 Fix notification API unit tests as part of CI/CD

### DIFF
--- a/apps/user-management/apps/notification-service/justfile
+++ b/apps/user-management/apps/notification-service/justfile
@@ -30,15 +30,12 @@ ci-build:
 
 # Test the .NET solution
 test:
-  @cd {{solution-root}} && dotnet test
-
-ci-test-temp1:
-  @true
-
-ci-test:
   @cd {{solution-root}}/../notification-service-test \
     && dotnet test --filter "FullyQualifiedName~DfeSwwEcf.NotificationService.Tests.UnitTests"
 
+ci-test:
+  @just test
+  
 # Publish the project
 package-component:
   @dotnet publish {{solution-root}} -c Release --no-restore


### PR DESCRIPTION
Changes for [SWIP-906](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-906) to only include unit tests for the Notification service as part of the build and publish image Github workflow. 
Excluding functional tests for now which are the reason for failures on the dotnet test command (they require the service to be available in order to call it). 

[SWIP-906]: https://dfedigital.atlassian.net/browse/SWIP-906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ