### PR TITLE
SWIP-1043 Load govuk styles as child theme css post process

### DIFF
--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/config.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/config.php
@@ -11,4 +11,11 @@ $THEME->name = 'govuk_swpdp';
  */
 $THEME->parents = ['govuk','boost'];
 
+$THEME->parents_exclude_sheets = [
+    'govuk' => ['govuk'],
+];
+
+// append govuk styles as a post process for theme styles to take precedence over boost
+$THEME->csspostprocess = 'theme_govuk_swpdp_csspostprocess';
+
 $THEME->rendererfactory = 'theme_overridden_renderer_factory';

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/lib.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/lib.php
@@ -1,0 +1,14 @@
+<?php
+defined('MOODLE_INTERNAL') || die();
+
+function theme_govuk_swpdp_csspostprocess(string $css, theme_config $theme): string {
+    global $CFG;
+
+    $govukpath = $CFG->dirroot . '/theme/govuk/style/govuk.css';
+    if (is_readable($govukpath)) {
+        $govukcss = file_get_contents($govukpath);
+        $css .=  $govukcss;
+    }
+
+    return $css;
+}

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/version.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/version.php
@@ -2,7 +2,6 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_govuk_swpdp';
-$plugin->version   = 2025090500;       
+$plugin->version   = 2025090501;       
 $plugin->requires  = 2023100900;       // 4.3+ (hooks available)
-$plugin->maturity  = MATURITY_ALPHA;
 $plugin->release   = '0.1';


### PR DESCRIPTION
Change for the Moodle child theme `govuk swpdp` to load the styles from the govuk theme as part of its css post process. We ensure we don't include the styles twice by excluding the sheet from being loaded as part of the parent. The issue this fixes relates to boost styles loading after the govuk theme styles in the child theme, which means we're seeing styles overrides not being applied.
As part of [SWIP-1043](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-1043) where the child theme was created.

[SWIP-1043]: https://dfedigital.atlassian.net/browse/SWIP-1043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ