### PR TITLE
SWIP-470 Resolve moodle SSO sign out issue

### DIFF
--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Controllers/OAuth2Controller.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/Controllers/OAuth2Controller.cs
@@ -245,11 +245,6 @@ public class OAuth2Controller(
                 "The OpenID Connect request cannot be retrieved."
             );
 
-        if (request.IdTokenHint is null)
-        {
-            return BadRequest();
-        }
-
         var authenticateResult = await HttpContext.AuthenticateAsync(
             OpenIddictServerAspNetCoreDefaults.AuthenticationScheme
         );


### PR DESCRIPTION
Fix worked on with @SamNich-Hippo and @IgiCodes for [SWIP-470](https://dfedigital.atlassian.net/browse/SWIP-470). When the ID token hint is empty there is handling in \apps\auth-service\Dfe.Sww.Ecf\src\Dfe.Sww.Ecf.AuthorizeAccess\Infrastructure\Configuration\ServiceExtensions.cs which uses the ID token to set the hint value. This code was not being reached due to the bad request being returned.