### PR TITLE
SWIP-1040 - docs: add feature flags documentation to service readmes

### DIFF
--- a/apps/user-management/apps/frontend/README.md
+++ b/apps/user-management/apps/frontend/README.md
@@ -1,10 +1,13 @@
-# Social Worker Workforce - Early Career Framework - Front End
+# Social Work Practice Development Programme Digital Service - User Management Front End
 
 ## Setup
+
 App settings will need to be provided to run the application locally. You will need to provide values for `SocialWorkEnglandClientOptions`. The required values are listed below.
 
 ### Social Work England Client Settings
+
 e.g.
+
 ```json
 "SocialWorkEnglandClientOptions": {
     "BaseUrl": "",
@@ -21,15 +24,17 @@ You will also need to provide values for the SWE API HTTP Client in a **.Net Use
 You will need to provide values for `SocialWorkEnglandClientOptions` secrets. The required values are listed below.
 
 e.g.
+
 ```json
 {
-  "SocialWorkEnglandClientOptions:ClientCredentials:ClientId": "",
-  "SocialWorkEnglandClientOptions:ClientCredentials:ClientSecret": "",
-  "SocialWorkEnglandClientOptions:ClientCredentials:AccessTokenUrl": ""
+    "SocialWorkEnglandClientOptions:ClientCredentials:ClientId": "",
+    "SocialWorkEnglandClientOptions:ClientCredentials:ClientSecret": "",
+    "SocialWorkEnglandClientOptions:ClientCredentials:AccessTokenUrl": ""
 }
 ```
 
 ### Moodle Service Client Settings
+
 ```json
 "MoodleClientOptions": {
     "BaseUrl": "https://moodle.ddev.site/webservice/rest/server.php"
@@ -37,7 +42,45 @@ e.g.
 ```
 
 You will also need to provide values for the Moodle Client in a **.Net User Secrets** file. **DO NOT PROVIDE THESE IN THE APP SETTINGS FILE**.
-You can obtain a new API key by following the `Create a Moodle a web service` section in the Moodle README. The README can be found here `social-work-induction-programme-digital-service\README.md` 
+You can obtain a new API key by following the `Create a Moodle a web service` section in the Moodle README. The README can be found here `social-work-induction-programme-digital-service\README.md`
+
 ```json
 "MoodleClientOptions:ApiToken": "{API_KEY}"
+```
+
+## Feature Flags
+
+The user management frontend uses feature flags to control various functionality. Feature flags are configured in the `appsettings.json` files and can be overridden using environment variables or other configuration sources.
+
+### Available Feature Flags
+
+| Flag                                    | Description                                                                                                                                                                               | Default Value                                |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
+| `EnableDeveloperExceptionPage`          | Provides detailed error information and stack traces during development to aid debugging                                                                                                  | `true` in Development, `false` in Production |
+| `EnableHttpStrictTransportSecurity`     | Enables HSTS security headers                                                                                                                                                             | `false` in Development, `true` in Production |
+| `EnableContentSecurityPolicyWorkaround` | Enables Content Security Policy workaround for ASP.NET Core auto refresh (see [dotnet/aspnetcore#33068](https://github.com/dotnet/aspnetcore/issues/33068))                               | `true` in Development, `false` in Production |
+| `EnableForwardedHeaders`                | Enables forwarded headers middleware for proxy support                                                                                                                                    | `true`                                       |
+| `EnableMoodleIntegration`               | Enables Moodle learning management system integration functionality                                                                                                                       | `true`                                       |
+| `EnablePlusEmailStripping`              | Enables removal of 'plus tags' (See [RFC 5233](https://www.rfc-editor.org/rfc/rfc5233) on Subaddress Extensions) from email addresses before sending emails via the Notification service. | `true`                                       |
+
+### Configuration
+
+Feature flags can be configured in several ways:
+
+1. **Environment-specific configuration files** (e.g., `appsettings.Development.json`, `appsettings.Production.json`)
+2. **Environment variables** (prefixed with the configuration section)
+3. **Azure App Configuration** (in production environments)
+4. **User secrets** (for local development)
+
+Example configuration in `appsettings.Development.json`:
+
+```json
+{
+    "FeatureFlags": {
+        "EnableDeveloperExceptionPage": true,
+        "EnableHttpStrictTransportSecurity": false,
+        "EnableMoodleIntegration": true,
+        "EnablePlusEmailStripping": true
+    }
+}
 ```


### PR DESCRIPTION
Adds 'Feature Flags' section to the READMEs for the `auth-service` and `user-management/apps/frontend` projects, detailing each feature flag that is currently implemented and a brief description of it's functionality.

Prettier also formatted the files as I was working on them, hence the various style changes throughout.