### PR TITLE
SWIP-1109 format empty db activity page

### DIFF
--- a/apps/moodle-ddev/plugins/theme/customlang_en/data.php
+++ b/apps/moodle-ddev/plugins/theme/customlang_en/data.php
@@ -25,4 +25,4 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$string['add'] = 'Add new evidence';
+$string['add'] = 'Add new direct observation';

--- a/apps/moodle-ddev/plugins/theme/customlang_en/data.php
+++ b/apps/moodle-ddev/plugins/theme/customlang_en/data.php
@@ -1,0 +1,28 @@
+<?php
+
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Local language pack
+ *
+ * @package    mod
+ * @subpackage data
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$string['add'] = 'Add new evidence';

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/classes/helpers/common_helpers.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/classes/helpers/common_helpers.php
@@ -1,0 +1,51 @@
+<?php
+namespace theme_govuk_swpdp\helpers;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Customise the primary navigation
+ */
+class common_helpers {
+
+    private static array $cache = [];
+
+    public static function is_staff_like(int $userid): bool {
+        global $CFG;
+        
+        if (array_key_exists($userid, self::$cache)) {
+            return self::$cache[$userid];
+        }
+
+        // system capabilities checks
+        $system = \context_system::instance();
+        if (is_siteadmin($userid) || has_any_capability([
+            'moodle/site:config',
+            'moodle/course:create',
+            'moodle/site:manageblocks'
+        ], $system, $userid)) {
+            return self::$cache[$userid] = true;
+        }
+        
+        // staff capabilities checks
+        require_once($CFG->libdir . '/enrollib.php');
+        $courses = enrol_get_users_courses($userid, true, 'id', 'sortorder ASC');
+        if (!$courses) { 
+            return self::$cache[$userid] = false; 
+        }
+
+        $staffcapabilities = [
+            'moodle/course:managegroups',
+            'moodle/competency:usercompetencyview'
+        ];
+
+        foreach ($courses as $course) {
+            $context = \context_course::instance($course->id);
+            if (has_any_capability($staffcapabilities, $context, $userid)) {
+                return self::$cache[$userid] = true;
+            }
+        }
+
+        return self::$cache[$userid] = false;
+    }
+}

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/config.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/config.php
@@ -11,11 +11,10 @@ $THEME->name = 'govuk_swpdp';
  */
 $THEME->parents = ['govuk','boost'];
 
-$THEME->parents_exclude_sheets = [
-    'govuk' => ['govuk'],
-];
-
-// append govuk styles as a post process for theme styles to take precedence over boost
-$THEME->csspostprocess = 'theme_govuk_swpdp_csspostprocess';
+$THEME->scss = function($theme) {
+    return theme_govuk_swpdp_get_main_scss_content($theme);
+};
+$THEME->prescsscallback   = 'theme_govuk_swpdp_get_pre_scss';
+$THEME->extrascsscallback = 'theme_govuk_swpdp_get_extra_scss';
 
 $THEME->rendererfactory = 'theme_overridden_renderer_factory';

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/lib.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/lib.php
@@ -31,15 +31,26 @@ function theme_govuk_swpdp_extend_settings_navigation($settingsnav, $context) {
     $settingsnav->add(get_string('myportfolio', 'theme_govuk_swpdp'), $url);
 }
 
+/**
+ * Main SCSS - add swpdp to govuk
+ */
 function theme_govuk_swpdp_get_main_scss_content($theme): string {
     $parentscss = theme_govuk_get_main_scss_content($theme);
     $themescss = @file_get_contents(__DIR__ . '/scss/govuk_swpdp.scss') ?: '';
     return $parentscss . "\n" . $themescss;
 }
+
+/**
+ * SCSS to prepend
+ */
 function theme_govuk_swpdp_get_pre_scss($theme): string {
     return theme_govuk_get_pre_scss($theme) . "\n" .
            (@file_get_contents(__DIR__ . '/scss/pre.scss') ?: '');
 }
+
+/**
+ * SCSS to append (after main bundle)
+ */
 function theme_govuk_swpdp_get_extra_scss($theme): string {
     return theme_govuk_get_extra_scss($theme) . "\n" .
            (@file_get_contents(__DIR__ . '/scss/post.scss') ?: '');

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/lib.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/lib.php
@@ -30,3 +30,17 @@ function theme_govuk_swpdp_extend_settings_navigation($settingsnav, $context) {
     $url = new moodle_url('/theme/govuk_swpdp/course_portfolio_settings.php', ['id' => $courseid]);
     $settingsnav->add(get_string('myportfolio', 'theme_govuk_swpdp'), $url);
 }
+
+function theme_govuk_swpdp_get_main_scss_content($theme): string {
+    $parentscss = theme_govuk_get_main_scss_content($theme);
+    $themescss = @file_get_contents(__DIR__ . '/scss/govuk_swpdp.scss') ?: '';
+    return $parentscss . "\n" . $themescss;
+}
+function theme_govuk_swpdp_get_pre_scss($theme): string {
+    return theme_govuk_get_pre_scss($theme) . "\n" .
+           (@file_get_contents(__DIR__ . '/scss/pre.scss') ?: '');
+}
+function theme_govuk_swpdp_get_extra_scss($theme): string {
+    return theme_govuk_get_extra_scss($theme) . "\n" .
+           (@file_get_contents(__DIR__ . '/scss/post.scss') ?: '');
+}

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
@@ -1,0 +1,18 @@
+<?php
+
+class theme_govuk_swpdp_core_renderer extends theme_govuk_core_renderer
+{
+    public function context_header($headerinfo = null, $headinglevel = 1): string {
+        // Clear the heading on database activity page with no entries
+        if ($this->page->pagetype === 'mod-data-view') {
+            try {
+                $manager = \mod_data\manager::create_from_coursemodule($this->page->cm);
+                if (!$manager->has_records()) {
+                    $this->page->set_heading('');
+                }
+            } catch (\Throwable $e) {}
+        }
+
+        return parent::context_header($headerinfo, $headinglevel);
+    }
+}

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
@@ -1,15 +1,11 @@
 <?php
 
+use theme_govuk_swpdp\helpers\common_helpers as Helpers;
+use core\output\single_select;
+
 class theme_govuk_swpdp_core_renderer extends theme_govuk_core_renderer
 {
-    public function header(): string {
-        if ($this->page->pagetype === 'mod-data-view') {
-            $this->page->set_heading('');
-        }
-        return parent::header();
-    }    
-
-    /** Hide breadcrumbs on pages within a course */
+    /* Hide breadcrumbs on pages within a course */
     public function navbar(): string
     {
         if (
@@ -19,5 +15,33 @@ class theme_govuk_swpdp_core_renderer extends theme_govuk_core_renderer
             return '';
         }
         return parent::navbar();
+    }
+
+    /* Empty header on view database page to hide course name */
+    public function header(): string {
+        if ($this->page->pagetype === 'mod-data-view') {
+            $this->page->set_heading('');
+        }
+        return parent::header();
+    }    
+
+    /* Hide groups dropdown on database view page for non staff */
+    protected function render_single_select(single_select $select): string {
+        if (!$this->is_staff_viewing_database()) {
+            $data = $select->export_for_template($this);
+            if ($data->name === 'group') {
+                return '';
+            }
+        }
+        $data = $select->export_for_template($this);
+        return $this->render_from_template('core/single_select', $data);
+    }
+
+    private function is_staff_viewing_database(): bool {
+        if ($this->page->pagetype !== 'mod-data-view') {
+            return false;
+        }
+        global $USER;
+        return Helpers::is_staff_like($USER->id);
     }
 }

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
@@ -2,19 +2,12 @@
 
 class theme_govuk_swpdp_core_renderer extends theme_govuk_core_renderer
 {
-    public function context_header($headerinfo = null, $headinglevel = 1): string {
-        // Clear the heading on database activity page with no entries
+    public function header(): string {
         if ($this->page->pagetype === 'mod-data-view') {
-            try {
-                $manager = \mod_data\manager::create_from_coursemodule($this->page->cm);
-                if (!$manager->has_records()) {
-                    $this->page->set_heading('');
-                }
-            } catch (\Throwable $e) {}
+            $this->page->set_heading('');
         }
-
-        return parent::context_header($headerinfo, $headinglevel);
-    }
+        return parent::header();
+    }    
 
     /** Hide breadcrumbs on pages within a course */
     public function navbar(): string

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
@@ -15,4 +15,16 @@ class theme_govuk_swpdp_core_renderer extends theme_govuk_core_renderer
 
         return parent::context_header($headerinfo, $headinglevel);
     }
+
+    /** Hide breadcrumbs on pages within a course */
+    public function navbar(): string
+    {
+        if (
+            $this->page->context &&
+            $this->page->context->get_course_context(false)
+        ) {
+            return '';
+        }
+        return parent::navbar();
+    }
 }

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
@@ -21,6 +21,7 @@ class theme_govuk_swpdp_core_renderer extends theme_govuk_core_renderer
     public function header(): string {
         if ($this->page->pagetype === 'mod-data-view') {
             $this->page->set_heading('');
+            $this->page->add_body_class('db-noheading');
         }
         return parent::header();
     }    

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/scss/govuk_swpdp.scss
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/scss/govuk_swpdp.scss
@@ -1,0 +1,15 @@
+.db-noheading #page-header .page-context-header.mb-2 {
+  padding: 0;
+  margin-bottom: 0 !important; 
+}
+
+// Style the h2 as a large heading when h1 is empty
+.db-noheading h2 {
+  @extend .govuk-heading-l;
+}
+
+.path-mod-data #page-content .groupselector:empty { display: none !important; }
+
+.path-mod-data #page-content .mb-3:has(> .groupselector:empty) {
+  margin-bottom: 0 !important;
+}

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/style/govuk_swpdp.css
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/style/govuk_swpdp.css
@@ -1,4 +1,0 @@
-#page-header .page-context-header.mb-2:has(.page-header-headings > h1.h2.mb-0:empty) {
-  padding: 0;
-  margin-bottom: 0 !important; 
-}

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/style/govuk_swpdp.css
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/style/govuk_swpdp.css
@@ -1,0 +1,4 @@
+#page-header .page-context-header.mb-2:has(.page-header-headings > h1.h2.mb-0:empty) {
+  padding: 0;
+  margin-bottom: 0 !important; 
+}

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/templates/mod_data/view_noentries.mustache
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/templates/mod_data/view_noentries.mustache
@@ -1,0 +1,63 @@
+{{!
+    This file is part of Moodle - http://moodle.org/
+    Moodle is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+    Moodle is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+    You should have received a copy of the GNU General Public License
+    along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+}}
+{{!
+    @template mod_data/view_noentries
+
+    Form containing all database presets displayed within a table.
+
+    Context variables required for this template:
+    * noitemsimgurl - The image url.
+    * importentriesbutton stdClass - Import entries single button to be rendered
+    * addentrybutton stdClass - Add entry single button to be rendered
+
+    Example context (json):
+    {
+        "noitemsimgurl": "https://moodlesite/theme/image.php/boost/mod_data/1535727318/nofields",
+        "importentriesbutton": {
+            "id" : "id1",
+            "method" : "get",
+            "url" : "#",
+            "primary" : false,
+            "tooltip" : "This is a tooltip",
+            "label" : "Button1",
+            "attributes": [
+                {
+                  "name": "data-attribute",
+                  "value": "no"
+                }
+            ]
+        },
+        "addentrybutton": {
+            "id" : "id2",
+            "method" : "get",
+            "url" : "#",
+            "primary" : true,
+            "tooltip" : "This is a tooltip",
+            "label" : "Button2",
+            "attributes": [
+                {
+                  "name": "data-attribute",
+                  "value": "yeah"
+                }
+            ]
+        }
+    }
+}}
+<div class="text-xs-center mt-4" data-region="empty-message">
+    <div class="mt-5 mb-0" id="action_bar">
+        {{#addentrybutton}}
+            {{> core/single_button }}
+        {{/addentrybutton}}
+    </div>
+</div>

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/version.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/version.php
@@ -2,6 +2,6 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'theme_govuk_swpdp';
-$plugin->version   = 2025092300;       
+$plugin->version   = 2025092500;       
 $plugin->requires  = 2023100900;       // 4.3+ (hooks available)
 $plugin->release   = '0.1';


### PR DESCRIPTION
Changes as part of [SWIP-1109](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-1109):

- empty h1 to remove the organisation name from the view database pages (both empty page and page with entries given the moodle template is common and this is as per Lucid designs); 
Also included styling override to ensure no empty space for the h1, and styled the heading which we want to display, the h2, as a large heading in this scenario. Future work needed to decide how we handle headings [SWIP-1169: Discuss and explore solution for page heading handling on database activities](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-1169)

- removal of group select option for ECSW (non staff users in the logic itself) and styling override to ensure no empty space on the page when this is done

- icon and “no entries yet“ text removed through template overwrite

- also included the logic that hides breadcrumbs in this theme instead of having it in the govuk theme

Alongside theme changes:

- language pack file created to change the text on the “Add entry“ button to “Add new direct observation“. The template used was global and therefore it has to be a language pack change. Ticket raised to automate the process of importing language pack files [SWIP-1168: Automate Moodle language pack files import as part of build and deploy](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-1168)

[SWIP-1109]: https://dfedigital.atlassian.net/browse/SWIP-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ