### PR TITLE
SWIP-1109 Hide groups text for ECSWs

### DIFF
--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/renderers.php
@@ -17,11 +17,17 @@ class theme_govuk_swpdp_core_renderer extends theme_govuk_core_renderer
         return parent::navbar();
     }
 
-    /* Empty header on view database page to hide course name */
+    /* Empty header on view database page to hide course name 
+    *  Add class for empty heading as css helper
+    *  Add class when non staff as css helper to hide group info 
+    */
     public function header(): string {
         if ($this->page->pagetype === 'mod-data-view') {
             $this->page->set_heading('');
             $this->page->add_body_class('db-noheading');
+            if (!$this->is_staff_viewing_database()) {
+                $this->page->add_body_class('no-group-menu');
+            }    
         }
         return parent::header();
     }    
@@ -39,7 +45,8 @@ class theme_govuk_swpdp_core_renderer extends theme_govuk_core_renderer
                     return '';
                 }
             }
-        }
+        } 
+
         return parent::heading($text, $level, $classes, $id);
     }
 

--- a/apps/moodle-ddev/plugins/theme/govuk_swpdp/style/govuk_swpdp.css
+++ b/apps/moodle-ddev/plugins/theme/govuk_swpdp/style/govuk_swpdp.css
@@ -56,3 +56,8 @@
         margin-bottom:30px
     }
 }
+
+/* Hide the text-only group info when .no-group-menu on view database */
+body.path-mod-data.no-group-menu .groupselector {
+  display: none !important;
+}


### PR DESCRIPTION
Not in original scope for [SWIP-1109](https://dfedigital.atlassian.net.mcas.ms/browse/SWIP-1109) to handle groups info display on the view database page. But given we will be using this feature for UR13, this has bee included in the work for this ticket. 

In my local setup, ECSWs happen to be in multiple groups per course. When the activity is configured to use groups, the select groups dropdown has been removed for ECSWs. 

When the ECSW is in only one group in the course, they see group text information in a div instead of the dropdown. This PR hides that information. It cannot be overriden through a renderer or mustache file, hence the css solution.
