### PR TITLE
SWIP-1180: ops(debug): disable auth service generic error page on d01 and local

### DIFF
--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/appsettings.Development.json
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.AuthorizeAccess/appsettings.Development.json
@@ -22,7 +22,7 @@
     "RequiresDbConnection": true,
     "EnableDeveloperExceptionPage": true,
     "EnableMigrationsEndpoint": true,
-    "EnableErrorExceptionHandler": true,
+    "EnableErrorExceptionHandler": false,
     "EnableContentSecurityPolicyWorkaround": true,
     "EnableDfeAnalytics": false,
     "EnableSwagger": true,
@@ -52,17 +52,9 @@
           "https://localhost:44394/oidc/logout-callback",
           "https://moodle.ddev.site/auth/oidc/logout.php"
         ],
-        "AllowedEndpoints": [
-          "authorization",
-          "logout",
-          "token"
-        ],
-        "AllowedGrantTypes": [
-          "authorization_code"
-        ],
-        "AllowedResponseTypes": [
-          "code"
-        ],
+        "AllowedEndpoints": ["authorization", "logout", "token"],
+        "AllowedGrantTypes": ["authorization_code"],
+        "AllowedResponseTypes": ["code"],
         "AllowedScopes": [
           "profile",
           "roles",

--- a/terraform/envs/d01/env.tfvars
+++ b/terraform/envs/d01/env.tfvars
@@ -29,6 +29,7 @@ moodle_instances = {
 # Enable dev friendly auth services features in dev environment
 auth_service_app_settings = {
   "FEATUREFLAGS__ENABLEDEVELOPEREXCEPTIONPAGE" = "true"
+  "FEATUREFLAGS__ENABLEERROREXCEPTIONHANDLER"  = "false"
   "FEATUREFLAGS__ENABLESWAGGER"                = "true"
   "DATABASESEED__PERSONID"                     = "00000000-0000-0000-0001-000000000001"
   "DATABASESEED__ROLEID"                       = 1000


### PR DESCRIPTION
Disabling the auth service's generic `/error` page on d01 and for local dev to help expose errors/exceptions occurring