### PR TITLE
SWIP-1116 - fix: Change user management phase banner to 'beta'

### DIFF
--- a/apps/user-management/apps/frontend/Pages/Shared/_Layout.cshtml
+++ b/apps/user-management/apps/frontend/Pages/Shared/_Layout.cshtml
@@ -47,7 +47,7 @@
 
 @section BeforeContent {
     <govuk-phase-banner>
-        <govuk-phase-banner-tag>Private Beta</govuk-phase-banner-tag>
+        <govuk-phase-banner-tag>Beta</govuk-phase-banner-tag>
         This is a new service - your <a href="#" class="govuk-link">feedback</a> will help us to improve it.
     </govuk-phase-banner>
 


### PR DESCRIPTION
<img width="569" height="108" alt="image" src="https://github.com/user-attachments/assets/eacf24c5-c796-4d9f-ae43-99fb0d010287" />
