### PR TITLE
SWIP-949 - feat(data): extend PersonEmailAddress max length

### DIFF
--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Mappings/PersonMapping.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Mappings/PersonMapping.cs
@@ -1,5 +1,5 @@
-using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Dfe.Sww.Ecf.Core.DataStore.Postgres.Models;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
 namespace Dfe.Sww.Ecf.Core.DataStore.Postgres.Mappings;
 
@@ -9,21 +9,21 @@ public class PersonMapping : IEntityTypeConfiguration<Person>
     {
         builder.ToTable("persons");
         builder.HasKey(p => p.PersonId);
+        builder.Property(p => p.PersonId).HasDefaultValueSql("gen_random_uuid()");
         builder.Property(o => o.CreatedOn).HasDefaultValueSql("now()");
         builder.HasIndex(p => p.Trn).HasFilter("trn is not null").IsUnique();
-        builder.Property(p => p.Trn).HasMaxLength(7).IsFixedLength();
-        builder.Property(p => p.FirstName).HasMaxLength(100).UseCollation("case_insensitive");
-        builder.Property(p => p.MiddleName).HasMaxLength(100).UseCollation("case_insensitive");
-        builder.Property(p => p.LastName).HasMaxLength(100).UseCollation("case_insensitive");
-        builder.Property(p => p.EmailAddress).HasMaxLength(100).UseCollation("case_insensitive");
-        builder.Property(p => p.NationalInsuranceNumber).HasMaxLength(9).IsFixedLength();
-        builder.Property(p => p.OtherGenderIdentity).HasMaxLength(100).UseCollation("case_insensitive");
-        builder.Property(p => p.OtherEthnicGroupWhite).HasMaxLength(100).UseCollation("case_insensitive");
-        builder.Property(p => p.OtherEthnicGroupAsian).HasMaxLength(100).UseCollation("case_insensitive");
-        builder.Property(p => p.OtherEthnicGroupMixed).HasMaxLength(100).UseCollation("case_insensitive");
-        builder.Property(p => p.OtherEthnicGroupBlack).HasMaxLength(100).UseCollation("case_insensitive");
-        builder.Property(p => p.OtherGenderIdentity).HasMaxLength(100).UseCollation("case_insensitive");
-        builder.Property(p => p.OtherEthnicGroupOther).HasMaxLength(100).UseCollation("case_insensitive");
-        builder.Property(p => p.OtherRouteIntoSocialWork).HasMaxLength(100).UseCollation("case_insensitive");
+        builder.Property(p => p.Trn).IsFixedLength();
+        builder.Property(p => p.FirstName).UseCollation("case_insensitive");
+        builder.Property(p => p.MiddleName).UseCollation("case_insensitive");
+        builder.Property(p => p.LastName).UseCollation("case_insensitive");
+        builder.Property(p => p.EmailAddress).UseCollation("case_insensitive");
+        builder.Property(p => p.NationalInsuranceNumber).IsFixedLength();
+        builder.Property(p => p.OtherGenderIdentity).UseCollation("case_insensitive");
+        builder.Property(p => p.OtherEthnicGroupWhite).UseCollation("case_insensitive");
+        builder.Property(p => p.OtherEthnicGroupAsian).UseCollation("case_insensitive");
+        builder.Property(p => p.OtherEthnicGroupMixed).UseCollation("case_insensitive");
+        builder.Property(p => p.OtherEthnicGroupBlack).UseCollation("case_insensitive");
+        builder.Property(p => p.OtherEthnicGroupOther).UseCollation("case_insensitive");
+        builder.Property(p => p.OtherRouteIntoSocialWork).UseCollation("case_insensitive");
     }
 }

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Migrations/20251007110740_SyncPersonsTable.Designer.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Migrations/20251007110740_SyncPersonsTable.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Dfe.Sww.Ecf.Core.DataStore.Postgres;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Dfe.Sww.Ecf.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(EcfDbContext))]
-    partial class EcfDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251007110740_SyncPersonsTable")]
+    partial class SyncPersonsTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Migrations/20251007110740_SyncPersonsTable.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Migrations/20251007110740_SyncPersonsTable.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.Sww.Ecf.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class SyncPersonsTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "person_id",
+                table: "persons",
+                type: "uuid",
+                nullable: false,
+                defaultValueSql: "gen_random_uuid()",
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Guid>(
+                name: "person_id",
+                table: "persons",
+                type: "uuid",
+                nullable: false,
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldDefaultValueSql: "gen_random_uuid()");
+        }
+    }
+}

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Migrations/20251007111150_ExtendPersonsEmailColumnLength.Designer.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Migrations/20251007111150_ExtendPersonsEmailColumnLength.Designer.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Dfe.Sww.Ecf.Core.DataStore.Postgres;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Dfe.Sww.Ecf.Core.DataStore.Postgres.Migrations
 {
     [DbContext(typeof(EcfDbContext))]
-    partial class EcfDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251007111150_ExtendPersonsEmailColumnLength")]
+    partial class ExtendPersonsEmailColumnLength
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Migrations/20251007111150_ExtendPersonsEmailColumnLength.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Migrations/20251007111150_ExtendPersonsEmailColumnLength.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Dfe.Sww.Ecf.Core.DataStore.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExtendPersonsEmailColumnLength : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "email_address",
+                table: "persons",
+                type: "character varying(254)",
+                maxLength: 254,
+                nullable: true,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(100)",
+                oldMaxLength: 100,
+                oldNullable: true,
+                oldCollation: "case_insensitive");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "email_address",
+                table: "persons",
+                type: "character varying(100)",
+                maxLength: 100,
+                nullable: true,
+                collation: "case_insensitive",
+                oldClrType: typeof(string),
+                oldType: "character varying(254)",
+                oldMaxLength: 254,
+                oldNullable: true,
+                oldCollation: "case_insensitive");
+        }
+    }
+}

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Models/Person.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Models/Person.cs
@@ -1,65 +1,61 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 using Dfe.Sww.Ecf.Core.DataStore.Postgres.Models.RegisterSocialWorker;
 
 namespace Dfe.Sww.Ecf.Core.DataStore.Postgres.Models;
 
 public class Person
 {
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public Guid PersonId { get; init; }
+
+    public int? ExternalUserId { get; set; }
+
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public DateTime? CreatedOn { get; set; }
+
     public DateTime? UpdatedOn { get; set; }
     public DateTime? DeletedOn { get; set; }
-    public string? Trn { get; set; }
-    public required string FirstName { get; set; }
-    public string? MiddleName { get; set; }
-    public required string LastName { get; set; }
-    public string? EmailAddress { get; set; }
-    public string? NationalInsuranceNumber { get; set; }
+
+    [Required][MaxLength(100)] public string FirstName { get; set; } = string.Empty;
+    [MaxLength(100)] public string? MiddleName { get; set; }
+    [Required][MaxLength(100)] public string LastName { get; set; } = string.Empty;
+
+    [MaxLength(100)] public string? EmailAddress { get; set; }
+    [MaxLength(9)] public string? NationalInsuranceNumber { get; set; }
+    [MaxLength(7)] public string? Trn { get; set; }
+
     public PersonStatus? Status { get; set; }
-    public int? ExternalUserId { get; set; }
-    public bool IsFunded { get; set; }
+
+    [Required] public bool IsFunded { get; set; }
+
     public DateOnly? ProgrammeStartDate { get; set; }
     public DateOnly? ProgrammeEndDate { get; set; }
 
     public DateOnly? DateOfBirth { get; set; }
-
     public UserSex? UserSex { get; set; }
-
     public GenderMatchesSexAtBirth? GenderMatchesSexAtBirth { get; set; }
-
-    public string? OtherGenderIdentity { get; set; }
+    [MaxLength(100)] public string? OtherGenderIdentity { get; set; }
 
     public EthnicGroup? EthnicGroup { get; set; }
-
     public EthnicGroupWhite? EthnicGroupWhite { get; set; }
-
-    public string? OtherEthnicGroupWhite { get; set; }
-
+    [MaxLength(100)] public string? OtherEthnicGroupWhite { get; set; }
     public EthnicGroupAsian? EthnicGroupAsian { get; set; }
-
-    public string? OtherEthnicGroupAsian { get; set; }
-
+    [MaxLength(100)] public string? OtherEthnicGroupAsian { get; set; }
     public EthnicGroupMixed? EthnicGroupMixed { get; set; }
-
-    public string? OtherEthnicGroupMixed { get; set; }
-
+    [MaxLength(100)] public string? OtherEthnicGroupMixed { get; set; }
     public EthnicGroupBlack? EthnicGroupBlack { get; set; }
-
-    public string? OtherEthnicGroupBlack { get; set; }
-
+    [MaxLength(100)] public string? OtherEthnicGroupBlack { get; set; }
     public EthnicGroupOther? EthnicGroupOther { get; set; }
-
-    public string? OtherEthnicGroupOther { get; set; }
+    [MaxLength(100)] public string? OtherEthnicGroupOther { get; set; }
 
     public Disability? Disability { get; set; }
 
     public DateOnly? SocialWorkEnglandRegistrationDate { get; set; }
-
     public Qualification? HighestQualification { get; set; }
-
     public RouteIntoSocialWork? RouteIntoSocialWork { get; set; }
-
-    public string? OtherRouteIntoSocialWork { get; set; }
-
+    [MaxLength(100)] public string? OtherRouteIntoSocialWork { get; set; }
     public int? SocialWorkQualificationEndYear { get; set; }
 
     public ICollection<PersonRole> PersonRoles { get; set; } = new List<PersonRole>();

--- a/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Models/Person.cs
+++ b/apps/auth-service/Dfe.Sww.Ecf/src/Dfe.Sww.Ecf.Core/DataStore/Postgres/Models/Person.cs
@@ -18,11 +18,11 @@ public class Person
     public DateTime? UpdatedOn { get; set; }
     public DateTime? DeletedOn { get; set; }
 
-    [Required][MaxLength(100)] public string FirstName { get; set; } = string.Empty;
+    [Required] [MaxLength(100)] public string FirstName { get; set; } = string.Empty;
     [MaxLength(100)] public string? MiddleName { get; set; }
-    [Required][MaxLength(100)] public string LastName { get; set; } = string.Empty;
+    [Required] [MaxLength(100)] public string LastName { get; set; } = string.Empty;
 
-    [MaxLength(100)] public string? EmailAddress { get; set; }
+    [MaxLength(254)] public string? EmailAddress { get; set; }
     [MaxLength(9)] public string? NationalInsuranceNumber { get; set; }
     [MaxLength(7)] public string? Trn { get; set; }
 


### PR DESCRIPTION
For SWIP-949:
- Updated Person model [MaxLength] attribute to 254 to align with [RFC 3696 Errata 1690](https://www.rfc-editor.org/errata/eid1690)
- Tested with an email that's exactly 254 characters: `long.email.address.testing.maximum.length.limit.abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz@subdomain1.subdomain2.subdomain3.reallylongdomainnamefortestingpurposes.thisisstillgoing.verylongdomainnameindeed.example.co.uk`
	<img width="302" height="277" alt="image" src="https://github.com/user-attachments/assets/b136d472-3723-4f72-96cd-e28c6e5db243" />


I also did the following:
- Added data annotations to Person model for key, required, and max length constraints to match DB
- Introduced DatabaseGenerated attributes for PersonId and CreatedOn
- Updated PersonMapping to set gen_random_uuid() default for PersonId to match DB
- Removed duplicate OtherGenderIdentity mapping
- Synced EF Core model snapshot with existing database defaults

This makes it a lot easier to generate migrations for Person model changes in the future. You can just update the model itself and then run `just ef migrations add <migration name>`. Previously, a bunch of properties were being defined elsewhere or just weren't present in EF's snapshot for some reason... so this brings everything back in sync.
I would have done this with all the other models to keep things unified but I only needed to touch the Person model for this ticket.