### PR TITLE
SWIP-1135 Bypass Azure Front Door in server to server calls

### DIFF
--- a/terraform/auth-service.tf
+++ b/terraform/auth-service.tf
@@ -54,6 +54,7 @@ module "auth_service" {
   docker_image_name         = "dfe-digital/nothing:latest"
   front_door_profile_web_id = module.stack.front_door_profile_web_id
   subnet_webapps_id         = module.stack.subnet_services_id
+  allow_subnet_ids          = [module.stack.subnet_services_id]
   acr_id                    = local.acr_id
   acr_name                  = var.acr_name
   key_vault_id              = module.stack.kv_id

--- a/terraform/modules/environment-stack/app-services.tf
+++ b/terraform/modules/environment-stack/app-services.tf
@@ -170,7 +170,7 @@ resource "azurerm_subnet" "sn_service_apps" {
   virtual_network_name              = azurerm_virtual_network.vnet_stack.name
   address_prefixes                  = ["10.0.5.0/24"]
   private_endpoint_network_policies = "Disabled"
-  service_endpoints                 = ["Microsoft.Sql"]
+  service_endpoints                 = ["Microsoft.Sql", "Microsoft.Web"]
 
   delegation {
     name = "delegation"

--- a/terraform/modules/web-app/variables.tf
+++ b/terraform/modules/web-app/variables.tf
@@ -94,6 +94,12 @@ variable "subnet_webapps_id" {
   type        = string
 }
 
+variable "allow_web_apps_snet" {
+  description = "Flag to allow web apps subnet traffic via access restriction rule"
+  type        = bool
+  default     = false
+}
+
 variable "docker_image_name" {
   description = "The Docker image name to use for the web app"
   type        = string

--- a/terraform/modules/web-app/variables.tf
+++ b/terraform/modules/web-app/variables.tf
@@ -98,7 +98,7 @@ variable "allow_subnet_ids" {
   description = "List of subnet IDs to allow via access restriction rules"
   type        = list(string)
   default     = []
-  }
+}
 
 variable "docker_image_name" {
   description = "The Docker image name to use for the web app"

--- a/terraform/modules/web-app/variables.tf
+++ b/terraform/modules/web-app/variables.tf
@@ -94,11 +94,11 @@ variable "subnet_webapps_id" {
   type        = string
 }
 
-variable "allow_web_apps_snet" {
-  description = "Flag to allow web apps subnet traffic via access restriction rule"
-  type        = bool
-  default     = false
-}
+variable "allow_subnet_ids" {
+  description = "List of subnet IDs to allow via access restriction rules"
+  type        = list(string)
+  default     = []
+  }
 
 variable "docker_image_name" {
   description = "The Docker image name to use for the web app"

--- a/terraform/modules/web-app/web-app.tf
+++ b/terraform/modules/web-app/web-app.tf
@@ -21,7 +21,16 @@ resource "azurerm_linux_web_app" "webapp" {
     ip_restriction_default_action = "Deny"
 
     ip_restriction {
+      name                      = "Access from services subnet"
+      priority                  = 100
+      action                    = "Allow"
+      virtual_network_subnet_id = module.stack.subnet_services_id
+    }
+
+    ip_restriction {
       name        = "Access from Front Door"
+      priority    = 200
+      action      = "Allow"
       service_tag = "AzureFrontDoor.Backend"
     }
 

--- a/terraform/modules/web-app/web-app.tf
+++ b/terraform/modules/web-app/web-app.tf
@@ -20,11 +20,14 @@ resource "azurerm_linux_web_app" "webapp" {
 
     ip_restriction_default_action = "Deny"
 
-    ip_restriction {
-      name                      = "Access from services subnet"
-      priority                  = 100
-      action                    = "Allow"
-      virtual_network_subnet_id = module.stack.subnet_services_id
+    dynamic "ip_restriction" {
+      for_each = var.allow_web_apps_snet ? [1] : []
+      content {
+        name                      = "Access from services subnet"
+        priority                  = 100
+        action                    = "Allow"
+        virtual_network_subnet_id = var.subnet_webapps_id
+      }
     }
 
     ip_restriction {

--- a/terraform/modules/web-app/web-app.tf
+++ b/terraform/modules/web-app/web-app.tf
@@ -21,12 +21,12 @@ resource "azurerm_linux_web_app" "webapp" {
     ip_restriction_default_action = "Deny"
 
     dynamic "ip_restriction" {
-      for_each = var.allow_web_apps_snet ? [1] : []
+      for_each = toset(var.allow_subnet_ids)
       content {
-        name                      = "Access from services subnet"
+        name                      = "Allow from subnet ${replace(element(split("/", ip_restriction.value), length(split("/", ip_restriction.value)) - 1), ".", "-")}"
         priority                  = 100
         action                    = "Allow"
-        virtual_network_subnet_id = var.subnet_webapps_id
+        virtual_network_subnet_id = ip_restriction.value
       }
     }
 

--- a/terraform/modules/web-app/web-app.tf
+++ b/terraform/modules/web-app/web-app.tf
@@ -23,7 +23,7 @@ resource "azurerm_linux_web_app" "webapp" {
     dynamic "ip_restriction" {
       for_each = toset(var.allow_subnet_ids)
       content {
-        name                      = "Allow from subnet ${replace(element(split("/", ip_restriction.value), length(split("/", ip_restriction.value)) - 1), ".", "-")}"
+        name                      = "Allow from subnet"
         priority                  = 100
         action                    = "Allow"
         virtual_network_subnet_id = ip_restriction.value

--- a/terraform/moodle-web-apps.tf
+++ b/terraform/moodle-web-apps.tf
@@ -115,6 +115,7 @@ module "web_app_moodle" {
   magic_link_token_value    = module.stack.magic_link_token_value
   magic_link_rule_set_id    = module.stack.magic_link_rule_set_id
   subnet_webapps_id         = module.stack.subnet_moodle_id
+  allow_web_apps_snet       = true
   acr_id                    = local.acr_id
   acr_name                  = var.acr_name
   key_vault_id              = module.stack.kv_id

--- a/terraform/moodle-web-apps.tf
+++ b/terraform/moodle-web-apps.tf
@@ -115,7 +115,7 @@ module "web_app_moodle" {
   magic_link_token_value    = module.stack.magic_link_token_value
   magic_link_rule_set_id    = module.stack.magic_link_rule_set_id
   subnet_webapps_id         = module.stack.subnet_moodle_id
-  allow_web_apps_snet       = true
+  allow_subnet_ids          = [module.stack.subnet_services_id]
   acr_id                    = local.acr_id
   acr_name                  = var.acr_name
   key_vault_id              = module.stack.kv_id

--- a/terraform/user-management.tf
+++ b/terraform/user-management.tf
@@ -36,7 +36,7 @@ module "user_management" {
     "OIDC__CLIENTID"                          = var.auth_service_client_id
     "OIDC__CLIENTSECRET"                      = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.auth_service_client_secret.name})"
     "SOCIALWORKENGLANDCLIENTOPTIONS__BASEURL" = "https://temp.placeholder.url.com" # TODO: SWE API usage deprioritised
-    "AUTHCLIENTOPTIONS__BASEURL"              = module.auth_service.web_app_url
+    "AUTHCLIENTOPTIONS__BASEURL"              = module.auth_service.front_door_app_url
     "MOODLECLIENTOPTIONS__BASEURL"            = "${module.web_app_moodle["primary"].web_app_url}/webservice/rest/server.php"
     "MOODLECLIENTOPTIONS__APITOKEN"           = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.web_service_token.name})"
     "NOTIFICATIONCLIENTOPTIONS__BASEURL"      = module.notification-service.function_app_url

--- a/terraform/user-management.tf
+++ b/terraform/user-management.tf
@@ -36,7 +36,7 @@ module "user_management" {
     "OIDC__CLIENTID"                          = var.auth_service_client_id
     "OIDC__CLIENTSECRET"                      = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.auth_service_client_secret.name})"
     "SOCIALWORKENGLANDCLIENTOPTIONS__BASEURL" = "https://temp.placeholder.url.com" # TODO: SWE API usage deprioritised
-    "AUTHCLIENTOPTIONS__BASEURL"              = module.auth_service.front_door_app_url
+    "AUTHCLIENTOPTIONS__BASEURL"              = module.auth_service.web_app_url
     "MOODLECLIENTOPTIONS__BASEURL"            = "${module.web_app_moodle["primary"].web_app_url}/webservice/rest/server.php"
     "MOODLECLIENTOPTIONS__APITOKEN"           = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.web_service_token.name})"
     "NOTIFICATIONCLIENTOPTIONS__BASEURL"      = module.notification-service.function_app_url

--- a/terraform/user-management.tf
+++ b/terraform/user-management.tf
@@ -37,7 +37,7 @@ module "user_management" {
     "OIDC__CLIENTSECRET"                      = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.auth_service_client_secret.name})"
     "SOCIALWORKENGLANDCLIENTOPTIONS__BASEURL" = "https://temp.placeholder.url.com" # TODO: SWE API usage deprioritised
     "AUTHCLIENTOPTIONS__BASEURL"              = module.auth_service.front_door_app_url
-    "MOODLECLIENTOPTIONS__BASEURL"            = "${module.web_app_moodle["primary"].front_door_app_url}/webservice/rest/server.php"
+    "MOODLECLIENTOPTIONS__BASEURL"            = "${module.web_app_moodle["primary"].web_app_url}/webservice/rest/server.php"
     "MOODLECLIENTOPTIONS__APITOKEN"           = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.web_service_token.name})"
     "NOTIFICATIONCLIENTOPTIONS__BASEURL"      = module.notification-service.function_app_url
     "NOTIFICATIONCLIENTOPTIONS__FUNCTIONKEY"  = "@Microsoft.KeyVault(SecretUri=${module.stack.kv_vault_uri}secrets/${azurerm_key_vault_secret.function_key.name})"


### PR DESCRIPTION
Changes made as part of [SWIP-1135](https://dfedigital.atlassian.net/browse/SWIP-1135) to:
- use the default hostname instead of the Azure Front Door one for the Moodle client and auth client in user management so server to server calls do not use Front Door
- enable web service endpoint for the auth and user management services subnet
- set up a mechanism to add allow traffic rules (access restrictions) for the moodle service and auth service when the traffic originates from the auth and user management services subnet for server to server calls

This resolves the issue of add new user calls from user management to Moodle throwing an error as they were missing the magic link token. 

To test:
- you can add someone
- you can view the list of users when logged in as a coordinator